### PR TITLE
sample markdown and workflow

### DIFF
--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -1,0 +1,34 @@
+name: Translate changes to Chinese
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  # -------------------------------------------------------------
+  # Event `pull_request`: Returns all changed pull request files.
+  # --------------------------------------------------------------
+  changed_files:
+    # NOTE:
+    # - This is limited to pull_request* events and would raise an error for other events.
+    # - A maximum of 3000 files can be returned.
+    # - For more flexibility and no limitations see "Using local .git directory" above.
+
+    runs-on: ubuntu-latest  # windows-latest || macos-latest
+    name: Test changed-files
+    permissions:
+      pull-requests: read
+
+    steps:
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v44
+
+      - name: List all changed files
+        env:
+          ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+        run: |
+          for file in ${ALL_CHANGED_FILES}; do
+            echo "$file was changed"
+          done

--- a/docs/en/quick_start/helm.md
+++ b/docs/en/quick_start/helm.md
@@ -1,0 +1,620 @@
+---
+displayed_sidebar: "English"
+description: Use Helm to deploy StarRocks
+toc_max_heading_level: 2
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import OperatorPrereqs from '../_assets/deployment/_OperatorPrereqs.mdx'
+import DDL from '../_assets/quick-start/_DDL.mdx'
+import Clients from '../_assets/quick-start/_clientsAllin1.mdx'
+import SQL from '../_assets/quick-start/_SQL.mdx'
+import Curl from '../_assets/quick-start/_curl.mdx'
+
+# StarRocks with Helm
+
+## Goals
+
+The goals of this quickstart are:
+
+- Deploy the StarRocks Kubernetes Operator and a StarRocks cluster with Helm
+- Configure a password for the StarRocks database user `root`
+- Provide for high-availability with three FEs and three BEs
+- Store metadata in persistent storage
+- Store data in persistent storage
+- Allow MySQL clients to connect from outside the Kubernetes cluster
+- Allow loading data from outside the Kubernetes cluster using Stream Load
+- Load some public datasets
+- Query the data
+
+:::tip
+The datasets and queries are the same as the ones used in the Basic Quick Start. The main difference here is deploying with Helm and the StarRocks Operator.
+:::
+
+The data used is provided by NYC OpenData and the National Centers for Environmental Information.
+
+Both of these datasets are large, and because this tutorial is intended to help you get exposed to working with StarRocks we are not going to load data for the past 120 years. You can run this with a GKE Kubernetes cluster built on three e2-standard-4 machines (or similar) with 80GB disk. For larger deployments, we have other documentation and will provide that later.
+
+There is a lot of information in this document, and it is presented with step-by-step content at the beginning, and the technical details at the end. This is done to serve these purposes in this order:
+
+1. Get the system deployed with Helm.
+2. Allow the reader to load data in StarRocks and analyze that data.
+3. Explain the basics of data transformation during loading.
+
+---
+
+## Prerequisites
+
+<OperatorPrereqs />
+
+### SQL client
+
+You can use the SQL client provided in the Kubernetes environment, or use one on your system. This guide uses the `mysql CLI` Many MySQL-compatible clients will work.
+
+### curl
+
+`curl` is used to issue the data load job to StarRocks, and to download the datasets. Check to see if you have it installed by running `curl` or `curl.exe` at your OS prompt. If curl is not installed, [get curl here](https://curl.se/dlwiz/?type=bin).
+
+---
+
+## Terminology
+
+### FE
+
+Frontend nodes are responsible for metadata management, client connection management, query planning, and query scheduling. Each FE stores and maintains a complete copy of metadata in its memory, which guarantees indiscriminate services among the FEs.
+
+### BE
+
+Backend nodes are responsible for both data storage and executing query plans.
+
+---
+
+## Add the StarRocks Helm chart repo
+
+The Helm Chart contains the definitions of the StarRocks Operator and the custom resource StarRocksCluster.
+1. Add the Helm Chart Repo.
+
+    ```Bash
+    helm repo add starrocks https://starrocks.github.io/starrocks-kubernetes-operator
+    ```
+
+2. Update the Helm Chart Repo to the latest version.
+
+      ```Bash
+      helm repo update
+      ```
+
+3. View the Helm Chart Repo that you added.
+
+      ```Bash
+      helm search repo starrocks
+      ```
+
+      ```
+      NAME                              	CHART VERSION	APP VERSION	DESCRIPTION
+      starrocks/kube-starrocks	1.9.7        	3.2-latest 	kube-starrocks includes two subcharts, operator...
+      starrocks/operator      	1.9.7        	1.9.7      	A Helm chart for StarRocks operator
+      starrocks/starrocks     	1.9.7        	3.2-latest 	A Helm chart for StarRocks cluster
+      starrocks/warehouse     	1.9.7        	3.2-latest 	Warehouse is currently a feature of the StarRoc...
+      ```
+
+---
+
+## Download the data
+
+Download these two datasets to your machine.
+
+### New York City crash data
+
+```bash
+curl -O https://raw.githubusercontent.com/StarRocks/demo/master/documentation-samples/quickstart/datasets/NYPD_Crash_Data.csv
+```
+
+### Weather data
+
+```bash
+curl -O https://raw.githubusercontent.com/StarRocks/demo/master/documentation-samples/quickstart/datasets/72505394728.csv
+```
+
+---
+
+## Create a Helm values file
+
+The goals for this quick start are:
+
+1. Configure a password for the StarRocks database user `root`
+2. Provide for high-availability with three FEs and three BEs
+3. Store metadata in persistent storage
+4. Store data in persistent storage
+5. Allow MySQL clients to connect from outside the Kubernetes cluster
+6. Allow loading data from outside the Kubernetes cluster using Stream Load
+
+The Helm chart provides options to satisfy all of these goals, but they are not configured by default. The rest of this section covers the configuration needed to meet all of these goals. A complete values spec will be provided, but first read the details for each of the six sections and then copy the full spec.
+
+### 1. Password for the database user
+
+This bit of YAML instructs the StarRocks operator to set the password for the database user `root` to the value of the `password` key of the Kubernetes secret `starrocks-root-pass.
+
+```yaml
+starrocks:
+    initPassword:
+        enabled: true
+        # Set a password secret, for example:
+        # kubectl create secret generic starrocks-root-pass --from-literal=password='g()()dpa$$word'
+        passwordSecret: starrocks-root-pass
+```
+
+- Task: Create the Kubernetes secret
+
+    ```bash
+    kubectl create secret generic starrocks-root-pass --from-literal=password='g()()dpa$$word'
+    ```
+
+### 2. High Availability with 3 FEs and 3 BEs
+
+By setting `starrocks.starrockFESpec.replicas` to 3, and `starrocks.starrockBeSpec.replicas` to 3 you will have enough FEs and BEs for high availability. Setting the CPU and memory requests low allows the pods to be created in a small Kubernetes environment.
+
+```yaml
+starrocks:
+    starrocksFESpec:
+        replicas: 3
+        resources:
+            requests:
+                cpu: 1
+                memory: 1Gi
+
+    starrocksBeSpec:
+        replicas: 3
+        resources:
+            requests:
+                cpu: 1
+                memory: 2Gi
+```
+
+### 3. Store metadata in persistent storage
+
+Setting a value for `starrocks.starrocksFESpec.storageSpec.name` to anything other than `""` causes:
+- Persistent storage to be used
+- the value of `starrocks.starrocksFESpec.storageSpec.name` to be used as the prefix for all storage volumes for the service.
+
+By setting the value to `fe` these PVs will be created for FE 0:
+
+- `fe-meta-kube-starrocks-fe-0`
+- `fe-log-kube-starrocks-fe-0`
+
+```yaml
+starrocks:
+    starrocksFESpec:
+        storageSpec:
+            name: fe
+```
+
+### 4. Store data in persistent storage
+
+Setting a value for `starrocks.starrocksBeSpec.storageSpec.name` to anything other than `""` causes:
+- Persistent storage to be used
+- the value of `starrocks.starrocksBeSpec.storageSpec.name` to be used as the prefix for all storage volumes for the service.
+
+By setting the value to `be` these PVs will be created for BE 0:
+
+- `be-data-kube-starrocks-be-0`
+- `be-log-kube-starrocks-be-0`
+
+Setting the `storageSize` to 15Gi reduces the storage from the default of 1Ti to fit smaller quotas for storage.
+
+```yaml
+starrocks:
+    starrocksBeSpec:
+        storageSpec:
+            name: be
+            storageSize: 15Gi
+```
+
+### 5. LoadBalancer for MySQL clients
+
+By default, access to the FE service is through cluster IPs. To allow external access, `service.type` is set to `LoadBalancer`
+
+```yaml
+starrocks:
+    starrocksFESpec:
+        service:
+            type: LoadBalancer
+```
+
+### 6. LoadBalancer for external data loading
+
+Stream Load requires external access to both FEs and BEs. The requests are sent to the FE and then the FE assigns a BE to process the upload. To allow the `curl` command to be redirected to the BE the `starroclFeProxySpec` needs to be enabled and set to type `LoadBalancer`.
+
+```yaml
+starrocks:
+    starrocksFeProxySpec:
+        enabled: true
+        service:
+            type: LoadBalancer
+```
+
+### The complete values file
+
+The above snippets combined provide a full values file. Save this to `my-values.yaml`:
+
+```yaml
+starrocks:
+    initPassword:
+        enabled: true
+        # Set a password secret, for example:
+        # kubectl create secret generic starrocks-root-pass --from-literal=password='g()()dpa$$word'
+        passwordSecret: starrocks-root-pass
+
+    starrocksFESpec:
+        replicas: 3
+        service:
+            type: LoadBalancer
+        resources:
+            requests:
+                cpu: 1
+                memory: 1Gi
+        storageSpec:
+            name: fe
+
+    starrocksBeSpec:
+        replicas: 3
+        resources:
+            requests:
+                cpu: 1
+                memory: 2Gi
+        storageSpec:
+            name: be
+            storageSize: 15Gi
+
+    starrocksFeProxySpec:
+        enabled: true
+        service:
+            type: LoadBalancer
+```
+
+## Set the StarRocks root database user password
+
+To load data from outside of the Kubernetes cluster the StarRocks database will be exposed externally. You should set
+a password for the StarRocks database user `root`. The operator will apply the password to the FE and BE nodes.
+
+```bash
+kubectl create secret generic starrocks-root-pass --from-literal=password='g()()dpa$$word'
+```
+
+```
+secret/starrocks-root-pass created
+```
+---
+
+## Deploy the operator and StarRocks cluster
+
+```bash
+helm install -f my-values.yaml starrocks starrocks/kube-starrocks
+```
+
+```
+NAME: starrocks
+LAST DEPLOYED: Wed Jun 26 20:25:09 2024
+NAMESPACE: default
+STATUS: deployed
+REVISION: 1
+TEST SUITE: None
+NOTES:
+Thank you for installing kube-starrocks-1.9.7 kube-starrocks chart.
+It will install both operator and starrocks cluster, please wait for a few minutes for the cluster to be ready.
+
+Please see the values.yaml for more operation information: https://github.com/StarRocks/starrocks-kubernetes-operator/blob/main/helm-charts/charts/kube-starrocks/values.yaml
+```
+
+## Check the status of the StarRocks cluster
+
+You can check the progress with these commands:
+
+```bash
+kubectl --namespace default get starrockscluster -l "cluster=kube-starrocks"
+```
+
+```
+NAME             PHASE         FESTATUS      BESTATUS      CNSTATUS   FEPROXYSTATUS
+kube-starrocks   reconciling   reconciling   reconciling              reconciling
+```
+
+```bash
+kubectl get pods
+```
+
+:::note
+The `kube-starrocks-initpwd` pod will go through `error` and `CrashLoopBackOff` states as it attempts to connect to the FE and BE pods to set the StarRocks root password. You should ignore these errors and wait for a status of `Completed` for this pod.
+:::
+
+```
+NAME                                       READY   STATUS             RESTARTS      AGE
+kube-starrocks-be-0                        0/1     Running            0             20s
+kube-starrocks-be-1                        0/1     Running            0             20s
+kube-starrocks-be-2                        0/1     Running            0             20s
+kube-starrocks-fe-0                        1/1     Running            0             66s
+kube-starrocks-fe-1                        0/1     Running            0             65s
+kube-starrocks-fe-2                        0/1     Running            0             66s
+kube-starrocks-fe-proxy-56f8998799-d4qmt   1/1     Running            0             20s
+kube-starrocks-initpwd-m84br               0/1     CrashLoopBackOff   3 (50s ago)   92s
+kube-starrocks-operator-54ffcf8c5c-xsjc8   1/1     Running            0             92s
+```
+
+```bash
+kubectl get pvc
+```
+
+```
+NAME                          STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   VOLUMEATTRIBUTESCLASS   AGE
+be-data-kube-starrocks-be-0   Bound    pvc-4ae0c9d8-7f9a-4147-ad74-b22569165448   15Gi       RWO            standard-rwo   <unset>                 82s
+be-data-kube-starrocks-be-1   Bound    pvc-28b4dbd1-0c8f-4b06-87e8-edec616cabbc   15Gi       RWO            standard-rwo   <unset>                 82s
+be-data-kube-starrocks-be-2   Bound    pvc-c7232ea6-d3d9-42f1-bfc1-024205a17656   15Gi       RWO            standard-rwo   <unset>                 82s
+be-log-kube-starrocks-be-0    Bound    pvc-6193c43d-c74f-4d12-afcc-c41ace3d5408   1Gi        RWO            standard-rwo   <unset>                 82s
+be-log-kube-starrocks-be-1    Bound    pvc-c01f124a-014a-439a-99a6-6afe95215bf0   1Gi        RWO            standard-rwo   <unset>                 82s
+be-log-kube-starrocks-be-2    Bound    pvc-136df15f-4d2e-43bc-a1c0-17227ce3fe6b   1Gi        RWO            standard-rwo   <unset>                 82s
+fe-log-kube-starrocks-fe-0    Bound    pvc-7eac524e-d286-4760-b21c-d9b6261d976f   5Gi        RWO            standard-rwo   <unset>                 2m23s
+fe-log-kube-starrocks-fe-1    Bound    pvc-38076b78-71e8-4659-b8e7-6751bec663f6   5Gi        RWO            standard-rwo   <unset>                 2m23s
+fe-log-kube-starrocks-fe-2    Bound    pvc-4ccfee60-02b7-40ba-a22e-861ea29dac74   5Gi        RWO            standard-rwo   <unset>                 2m23s
+fe-meta-kube-starrocks-fe-0   Bound    pvc-5130c9ff-b797-4f79-a1d2-4214af860d70   10Gi       RWO            standard-rwo   <unset>                 2m23s
+fe-meta-kube-starrocks-fe-1   Bound    pvc-13545330-63be-42cf-b1ca-3ed6f96a8c98   10Gi       RWO            standard-rwo   <unset>                 2m23s
+fe-meta-kube-starrocks-fe-2   Bound    pvc-609cadd4-c7b7-4cf9-84b0-a75678bb3c4d   10Gi       RWO            standard-rwo   <unset>                 2m23s
+```
+### Verify that the cluster is healthy
+
+:::tip
+These are the same commands as above, but show the desired state.
+:::
+
+```bash
+kubectl --namespace default get starrockscluster -l "cluster=kube-starrocks"
+```
+
+```
+NAME             PHASE     FESTATUS   BESTATUS   CNSTATUS   FEPROXYSTATUS
+kube-starrocks   running   running    running               running
+```
+
+```bash
+kubectl get pods
+```
+
+:::tip
+The system is ready when all of the pods except for `kube-starrocks-initpwd` show `1/1` in the `READY` column. The `kube-starrocks-initpwd` pod should show `0/1` and a `STATUS` of `Completed`.
+:::
+
+```
+NAME                                       READY   STATUS      RESTARTS   AGE
+kube-starrocks-be-0                        1/1     Running     0          57s
+kube-starrocks-be-1                        1/1     Running     0          57s
+kube-starrocks-be-2                        1/1     Running     0          57s
+kube-starrocks-fe-0                        1/1     Running     0          103s
+kube-starrocks-fe-1                        1/1     Running     0          102s
+kube-starrocks-fe-2                        1/1     Running     0          103s
+kube-starrocks-fe-proxy-56f8998799-d4qmt   1/1     Running     0          57s
+kube-starrocks-initpwd-m84br               0/1     Completed   4          2m9s
+kube-starrocks-operator-54ffcf8c5c-xsjc8   1/1     Running     0          2m9s
+```
+
+The `EXTERNAL-IP` addresses in the highlighted lines will be used to provide SQL client and Stream Load access from outside the Kubernetes cluster.
+
+```bash
+kubectl get services
+```
+
+```bash
+NAME                              TYPE           CLUSTER-IP       EXTERNAL-IP     PORT(S)                                                       AGE
+kube-starrocks-be-search          ClusterIP      None             <none>          9050/TCP                                                      78s
+kube-starrocks-be-service         ClusterIP      34.118.228.231   <none>          9060/TCP,8040/TCP,9050/TCP,8060/TCP                           78s
+# highlight-next-line
+kube-starrocks-fe-proxy-service   LoadBalancer   34.118.230.176   34.176.12.205   8080:30241/TCP                                                78s
+kube-starrocks-fe-search          ClusterIP      None             <none>          9030/TCP                                                      2m4s
+# highlight-next-line
+kube-starrocks-fe-service         LoadBalancer   34.118.226.82    34.176.215.97   8030:30620/TCP,9020:32461/TCP,9030:32749/TCP,9010:30911/TCP   2m4s
+kubernetes                        ClusterIP      34.118.224.1     <none>          443/TCP                                                       8h
+```
+
+:::tip
+Store the `EXTERNAL-IP` addresses from the highlighted lines in environment variables so that you have them handy:
+
+```
+export MYSQL_IP=`kubectl get services kube-starrocks-fe-service --output jsonpath='{.status.loadBalancer.ingress[0].ip}'`
+```
+```
+export FE_PROXY=`kubectl get services kube-starrocks-fe-proxy-service --output jsonpath='{.status.loadBalancer.ingress[0].ip}'`:8080
+```
+:::
+
+
+
+---
+
+### Connect to StarRocks with a SQL client
+
+:::tip
+
+If you are using a client other than the mysql CLI, open that now.
+:::
+
+This command will run the `mysql` command in a Kubernetes pod:
+
+```sql
+kubectl exec --stdin --tty kube-starrocks-fe-0 -- \
+  mysql -P9030 -h127.0.0.1 -u root --prompt="StarRocks > "
+```
+
+If you have the mysql CLI installed locally, you can use it instead of the one in the Kubernetes cluster:
+
+```sql
+mysql -P9030 -h $MYSQL_IP -u root --prompt="StarRocks > " -p
+```
+
+---
+## Create some tables
+
+```bash
+mysql -P9030 -h $MYSQL_IP -u root --prompt="StarRocks > " -p
+```
+
+
+<DDL />
+
+Exit from the MySQL client, or open a new shell to run commands at the command line to upload data.
+
+```sql
+exit
+```
+
+
+
+## Upload data
+
+There are many ways to load data into StarRocks. For this tutorial, the simplest way is to use curl and StarRocks Stream Load.
+
+Upload the two datasets that you downloaded earlier.
+
+:::tip
+Open a new shell as these curl commands are run at the operating system prompt, not in the `mysql` client. The commands refer to the datasets that you downloaded, so run them from the directory where you downloaded the files.
+
+Since this is a new shell, run the export commands again:
+
+```bash
+
+export MYSQL_IP=`kubectl get services kube-starrocks-fe-service --output jsonpath='{.status.loadBalancer.ingress[0].ip}'`
+
+export FE_PROXY=`kubectl get services kube-starrocks-fe-proxy-service --output jsonpath='{.status.loadBalancer.ingress[0].ip}'`:8080
+```
+
+You will be prompted for a password. Use the password that you added to the Kubernetes secret `starrocks-root-pass`. If you used the command provided, the password is `g()()dpa$$word`.
+:::
+
+The `curl` commands look complex, but they are explained in detail at the end of the tutorial. For now, we recommend running the commands and running some SQL to analyze the data, and then reading about the data loading details at the end.
+
+
+```bash
+curl --location-trusted -u root             \
+    -T ./NYPD_Crash_Data.csv                \
+    -H "label:crashdata-0"                  \
+    -H "column_separator:,"                 \
+    -H "skip_header:1"                      \
+    -H "enclose:\""                         \
+    -H "max_filter_ratio:1"                 \
+    -H "columns:tmp_CRASH_DATE, tmp_CRASH_TIME, CRASH_DATE=str_to_date(concat_ws(' ', tmp_CRASH_DATE, tmp_CRASH_TIME), '%m/%d/%Y %H:%i'),BOROUGH,ZIP_CODE,LATITUDE,LONGITUDE,LOCATION,ON_STREET_NAME,CROSS_STREET_NAME,OFF_STREET_NAME,NUMBER_OF_PERSONS_INJURED,NUMBER_OF_PERSONS_KILLED,NUMBER_OF_PEDESTRIANS_INJURED,NUMBER_OF_PEDESTRIANS_KILLED,NUMBER_OF_CYCLIST_INJURED,NUMBER_OF_CYCLIST_KILLED,NUMBER_OF_MOTORIST_INJURED,NUMBER_OF_MOTORIST_KILLED,CONTRIBUTING_FACTOR_VEHICLE_1,CONTRIBUTING_FACTOR_VEHICLE_2,CONTRIBUTING_FACTOR_VEHICLE_3,CONTRIBUTING_FACTOR_VEHICLE_4,CONTRIBUTING_FACTOR_VEHICLE_5,COLLISION_ID,VEHICLE_TYPE_CODE_1,VEHICLE_TYPE_CODE_2,VEHICLE_TYPE_CODE_3,VEHICLE_TYPE_CODE_4,VEHICLE_TYPE_CODE_5" \
+    # highlight-next-line
+    -XPUT http://$FE_PROXY/api/quickstart/crashdata/_stream_load
+```
+
+```
+Enter host password for user 'root':
+{
+    "TxnId": 2,
+    "Label": "crashdata-0",
+    "Status": "Success",
+    "Message": "OK",
+    "NumberTotalRows": 423726,
+    "NumberLoadedRows": 423725,
+    "NumberFilteredRows": 1,
+    "NumberUnselectedRows": 0,
+    "LoadBytes": 96227746,
+    "LoadTimeMs": 2483,
+    "BeginTxnTimeMs": 42,
+    "StreamLoadPlanTimeMs": 122,
+    "ReadDataTimeMs": 1610,
+    "WriteDataTimeMs": 2253,
+    "CommitAndPublishTimeMs": 65,
+    "ErrorURL": "http://kube-starrocks-be-2.kube-starrocks-be-search.default.svc.cluster.local:8040/api/_load_error_log?file=error_log_5149e6f80de42bcb_eab2ea77276de4ba"
+}
+```
+
+```bash
+curl --location-trusted -u root             \
+    -T ./72505394728.csv                    \
+    -H "label:weather-0"                    \
+    -H "column_separator:,"                 \
+    -H "skip_header:1"                      \
+    -H "enclose:\""                         \
+    -H "max_filter_ratio:1"                 \
+    -H "columns: STATION, DATE, LATITUDE, LONGITUDE, ELEVATION, NAME, REPORT_TYPE, SOURCE, HourlyAltimeterSetting, HourlyDewPointTemperature, HourlyDryBulbTemperature, HourlyPrecipitation, HourlyPresentWeatherType, HourlyPressureChange, HourlyPressureTendency, HourlyRelativeHumidity, HourlySkyConditions, HourlySeaLevelPressure, HourlyStationPressure, HourlyVisibility, HourlyWetBulbTemperature, HourlyWindDirection, HourlyWindGustSpeed, HourlyWindSpeed, Sunrise, Sunset, DailyAverageDewPointTemperature, DailyAverageDryBulbTemperature, DailyAverageRelativeHumidity, DailyAverageSeaLevelPressure, DailyAverageStationPressure, DailyAverageWetBulbTemperature, DailyAverageWindSpeed, DailyCoolingDegreeDays, DailyDepartureFromNormalAverageTemperature, DailyHeatingDegreeDays, DailyMaximumDryBulbTemperature, DailyMinimumDryBulbTemperature, DailyPeakWindDirection, DailyPeakWindSpeed, DailyPrecipitation, DailySnowDepth, DailySnowfall, DailySustainedWindDirection, DailySustainedWindSpeed, DailyWeather, MonthlyAverageRH, MonthlyDaysWithGT001Precip, MonthlyDaysWithGT010Precip, MonthlyDaysWithGT32Temp, MonthlyDaysWithGT90Temp, MonthlyDaysWithLT0Temp, MonthlyDaysWithLT32Temp, MonthlyDepartureFromNormalAverageTemperature, MonthlyDepartureFromNormalCoolingDegreeDays, MonthlyDepartureFromNormalHeatingDegreeDays, MonthlyDepartureFromNormalMaximumTemperature, MonthlyDepartureFromNormalMinimumTemperature, MonthlyDepartureFromNormalPrecipitation, MonthlyDewpointTemperature, MonthlyGreatestPrecip, MonthlyGreatestPrecipDate, MonthlyGreatestSnowDepth, MonthlyGreatestSnowDepthDate, MonthlyGreatestSnowfall, MonthlyGreatestSnowfallDate, MonthlyMaxSeaLevelPressureValue, MonthlyMaxSeaLevelPressureValueDate, MonthlyMaxSeaLevelPressureValueTime, MonthlyMaximumTemperature, MonthlyMeanTemperature, MonthlyMinSeaLevelPressureValue, MonthlyMinSeaLevelPressureValueDate, MonthlyMinSeaLevelPressureValueTime, MonthlyMinimumTemperature, MonthlySeaLevelPressure, MonthlyStationPressure, MonthlyTotalLiquidPrecipitation, MonthlyTotalSnowfall, MonthlyWetBulb, AWND, CDSD, CLDD, DSNW, HDSD, HTDD, NormalsCoolingDegreeDay, NormalsHeatingDegreeDay, ShortDurationEndDate005, ShortDurationEndDate010, ShortDurationEndDate015, ShortDurationEndDate020, ShortDurationEndDate030, ShortDurationEndDate045, ShortDurationEndDate060, ShortDurationEndDate080, ShortDurationEndDate100, ShortDurationEndDate120, ShortDurationEndDate150, ShortDurationEndDate180, ShortDurationPrecipitationValue005, ShortDurationPrecipitationValue010, ShortDurationPrecipitationValue015, ShortDurationPrecipitationValue020, ShortDurationPrecipitationValue030, ShortDurationPrecipitationValue045, ShortDurationPrecipitationValue060, ShortDurationPrecipitationValue080, ShortDurationPrecipitationValue100, ShortDurationPrecipitationValue120, ShortDurationPrecipitationValue150, ShortDurationPrecipitationValue180, REM, BackupDirection, BackupDistance, BackupDistanceUnit, BackupElements, BackupElevation, BackupEquipment, BackupLatitude, BackupLongitude, BackupName, WindEquipmentChangeDate" \
+    # highlight-next-line
+    -XPUT http://$FE_PROXY/api/quickstart/weatherdata/_stream_load
+```
+
+```
+Enter host password for user 'root':
+{
+    "TxnId": 4,
+    "Label": "weather-0",
+    "Status": "Success",
+    "Message": "OK",
+    "NumberTotalRows": 22931,
+    "NumberLoadedRows": 22931,
+    "NumberFilteredRows": 0,
+    "NumberUnselectedRows": 0,
+    "LoadBytes": 15558550,
+    "LoadTimeMs": 404,
+    "BeginTxnTimeMs": 1,
+    "StreamLoadPlanTimeMs": 7,
+    "ReadDataTimeMs": 157,
+    "WriteDataTimeMs": 372,
+    "CommitAndPublishTimeMs": 23
+}
+```
+
+## Connect with a MySQL client
+
+Connect with a MySQL client if you are not connected. Remember to use the external IP address of the `kube-starrocks-fe-service` service and the password that you configured in the Kubernetes secret `starrocks-root-pass`.
+
+```bash
+mysql -P9030 -h $MYSQL_IP -u root --prompt="StarRocks > " -p
+```
+
+## Answer some questions
+
+<SQL />
+
+```sql
+exit
+```
+
+## Cleanup
+
+Run this command if you are finished and would like to remove the StarRocks cluster and the StarRocks operator.
+
+```bash
+helm delete starrocks
+```
+
+
+---
+
+## Summary
+
+In this tutorial you:
+
+- Deployed StarRocks with Helm and the StarRocks Operator
+- Loaded crash data provided by New York City and weather data provided by NOAA
+- Analyzed the data using SQL JOINs to find out that driving in low visibility or icy streets is a bad idea
+
+There is more to learn; we intentionally glossed over the data transformation done during the Stream Load. The details on that are in the notes on the curl commands below.
+
+---
+
+## Notes on the curl commands
+
+<Curl />
+
+---
+
+## More information
+
+Default [`values.yaml`](https://github.com/StarRocks/starrocks-kubernetes-operator/blob/main/helm-charts/charts/kube-starrocks/values.yaml)
+
+[Stream Load](../sql-reference/sql-statements/data-manipulation/STREAM_LOAD.md)
+
+The [Motor Vehicle Collisions - Crashes](https://data.cityofnewyork.us/Public-Safety/Motor-Vehicle-Collisions-Crashes/h9gi-nx95) dataset is provided by New York City subject to these [terms of use](https://www.nyc.gov/home/terms-of-use.page) and [privacy policy](https://www.nyc.gov/home/privacy-policy.page).
+
+The [Local Climatological Data](https://www.ncdc.noaa.gov/cdo-web/datatools/lcd)(LCD) is provided by NOAA with this [disclaimer](https://www.noaa.gov/disclaimer) and this [privacy policy](https://www.noaa.gov/protecting-your-privacy).
+
+[Helm](https://helm.sh/) is a package manager for Kubernetes. A [Helm Chart](https://helm.sh/docs/topics/charts/) is a Helm package and contains all of the resource definitions necessary to run an application on a Kubernetes cluster.
+
+[`starrocks-kubernetes-operator` and `kube-starrocks` Helm Chart](https://github.com/StarRocks/starrocks-kubernetes-operator).

--- a/docs/en/quick_start/hudi.md
+++ b/docs/en/quick_start/hudi.md
@@ -1,0 +1,414 @@
+---
+displayed_sidebar: "English"
+sidebar_position: 4
+description: Data Lakehouse with Apache Hudi
+toc_max_heading_level: 3
+---
+import DataLakeIntro from '../_assets/commonMarkdown/datalakeIntro.md'
+import Clients from '../_assets/quick-start/_clientsCompose.mdx'
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Apache Hudi Lakehouse
+
+## Overview
+
+- Deploy Object Storage, Apache Spark, Hudi, and StarRocks using Docker compose
+- Load a tiny dataset into Hudi with Apache Spark
+- Configure StarRocks to access the Hive Metastore using an external catalog
+- Query the data with StarRocks where the data sits
+
+<DataLakeIntro />
+
+## Prerequisites
+
+### StarRocks `demo` repository
+
+Clone the [StarRocks demo repository](https://github.com/StarRocks/demo/) to your local machine.
+
+All the steps in this guide will be run from the `demo/documentation-samples/hudi/` directory in the directory where you cloned the `demo` GitHub repo.
+
+### Docker
+
+- Docker Setup: For Mac, Please follow the steps as defined in [Install Docker Desktop on Mac](https://docs.docker.com/desktop/install/mac-install/). For running Spark-SQL queries, please ensure at least 5 GB memory and 4 CPUs are allocated to Docker (See Docker → Preferences → Advanced). Otherwise, spark-SQL queries could be killed because of memory issues.
+- 20 GB free disk space assigned to Docker
+  
+### SQL client
+
+You can use the SQL client provided in the Docker environment, or use one on your system. Many MySQL compatible clients will work.
+
+## Configuration
+
+Change directory into `demo/documentation-samples/hudi` and look at the files. This is not a tutorial on Hudi, so not every configuration file will be described; but it is important for the reader to know where to look to see how things are configured. In the `hudi/` directory you will find the `docker-compose.yml` file which is used to launch and configure the services in Docker. Here is a list of those services and a brief description:
+
+### Docker services
+
+| Service                  | Responsibilities                                                    |
+|--------------------------|---------------------------------------------------------------------|
+| **`starrocks-fe`**       | Metadata management, client connections, query plans and scheduling |
+| **`starrocks-be`**       | Running query plans                                                 |
+| **`metastore_db`**       | Postgres DB used to store the Hive metadata                         |
+| **`hive_metastore`**     | Provides the Apache Hive metastore                                  |
+| **`minio`** and **`mc`** | MinIO Object Storage and MinIO command line client                  |
+| **`spark-hudi`**         | Distributed computing and Transactional data lake platform          |
+
+### Configuration files
+
+In the `hudi/conf/` directory you will find configuration files that get mounted in the `spark-hudi`
+container.
+
+##### `core-site.xml`
+
+This file contains the object storage related settings. Links for this and other items in More information at the end of this document.
+
+##### `spark-defaults.conf`
+
+Settings for Hive, MinIO, and Spark SQL.
+
+##### `hudi-defaults.conf`
+
+Default file used to silence warnings in the `spark-shell`.
+
+##### `hadoop-metrics2-hbase.properties`
+
+Empty file used to silence warnings in the `spark-shell`.
+
+##### `hadoop-metrics2-s3a-file-system.properties`
+
+Empty file used to silence warnings in the `spark-shell`.
+
+## Bringing up Demo Cluster
+
+This demo system consists of StarRocks, Hudi, MinIO, and Spark services. Run Docker compose to bring up the cluster:
+
+```bash
+docker compose up --detach --wait --wait-timeout 60
+```
+
+```plaintext
+[+] Running 8/8
+ ✔ Network hudi                     Created                                                   0.0s
+ ✔ Container hudi-starrocks-fe-1    Healthy                                                   0.1s
+ ✔ Container hudi-minio-1           Healthy                                                   0.1s
+ ✔ Container hudi-metastore_db-1    Healthy                                                   0.1s
+ ✔ Container hudi-starrocks-be-1    Healthy                                                   0.0s
+ ✔ Container hudi-mc-1              Healthy                                                   0.0s
+ ✔ Container hudi-hive-metastore-1  Healthy                                                   0.0s
+ ✔ Container hudi-spark-hudi-1      Healthy                                                   0.1s
+ ```
+
+:::tip
+
+With many containers running, `docker compose ps` output is easier to read if you pipe it to `jq`:
+
+```bash
+docker compose ps --format json | \
+jq '{Service: .Service, State: .State, Status: .Status}'
+```
+
+```json
+{
+  "Service": "hive-metastore",
+  "State": "running",
+  "Status": "Up About a minute (healthy)"
+}
+{
+  "Service": "mc",
+  "State": "running",
+  "Status": "Up About a minute"
+}
+{
+  "Service": "metastore_db",
+  "State": "running",
+  "Status": "Up About a minute"
+}
+{
+  "Service": "minio",
+  "State": "running",
+  "Status": "Up About a minute"
+}
+{
+  "Service": "spark-hudi",
+  "State": "running",
+  "Status": "Up 33 seconds (healthy)"
+}
+{
+  "Service": "starrocks-be",
+  "State": "running",
+  "Status": "Up About a minute (healthy)"
+}
+{
+  "Service": "starrocks-fe",
+  "State": "running",
+  "Status": "Up About a minute (healthy)"
+}
+```
+
+:::
+
+## Configure MinIO
+
+When you run the Spark commands you will set the basepath for the table being created to an `s3a` URI:
+
+```java
+val basePath = "s3a://huditest/hudi_coders"
+```
+
+In this step you will create the bucket `huditest` in MinIO. The MinIO console is running on port `9000`.
+
+### Authenticate to MinIO
+
+Open a browser to [http://localhost:9000/](http://localhost:9000/) and authenticate. The username and password are specified in `docker-compose.yml`; they are `admin` and `password`.
+
+### Create a bucket
+
+In the left navigation select **Buckets**, and then **Create Bucket +**. Name the bucket `huditest` and select **Create Bucket**
+
+![Create bucket huditest](../_assets/quick-start/hudi-test-bucket.png)
+
+## Create and populate a table, then sync it to Hive
+
+:::tip
+
+Run this command, and any other `docker compose` commands, from the directory containing the `docker-compose.yml` file.
+:::
+
+Open `spark-shell` in the `spark-hudi` service
+
+```bash
+docker compose exec spark-hudi spark-shell
+```
+
+:::note
+There will be warnings when `spark-shell` starts about illegal reflective access. You can ignore these warnings.
+:::
+
+Run these commands at the `scala>` prompt to:
+
+- Configure this Spark session to load, process, and write data
+- Create a dataframe and write that to a Hudi table
+- Sync to the Hive Metastore
+
+```scala
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.SaveMode._
+import org.apache.hudi.DataSourceReadOptions._
+import org.apache.hudi.DataSourceWriteOptions._
+import org.apache.hudi.config.HoodieWriteConfig._
+import scala.collection.JavaConversions._
+
+val schema = StructType( Array(
+                 StructField("language", StringType, true),
+                 StructField("users", StringType, true),
+                 StructField("id", StringType, true)
+             ))
+
+val rowData= Seq(Row("Java", "20000", "a"),
+               Row("Python", "100000", "b"),
+               Row("Scala", "3000", "c"))
+
+
+val df = spark.createDataFrame(rowData,schema)
+
+val databaseName = "hudi_sample"
+val tableName = "hudi_coders_hive"
+val basePath = "s3a://huditest/hudi_coders"
+
+df.write.format("hudi").
+  option(org.apache.hudi.config.HoodieWriteConfig.TABLE_NAME, tableName).
+  option(RECORDKEY_FIELD_OPT_KEY, "id").
+  option(PARTITIONPATH_FIELD_OPT_KEY, "language").
+  option(PRECOMBINE_FIELD_OPT_KEY, "users").
+  option("hoodie.datasource.write.hive_style_partitioning", "true").
+  option("hoodie.datasource.hive_sync.enable", "true").
+  option("hoodie.datasource.hive_sync.mode", "hms").
+  option("hoodie.datasource.hive_sync.database", databaseName).
+  option("hoodie.datasource.hive_sync.table", tableName).
+  option("hoodie.datasource.hive_sync.partition_fields", "language").
+  option("hoodie.datasource.hive_sync.partition_extractor_class", "org.apache.hudi.hive.MultiPartKeysValueExtractor").
+  option("hoodie.datasource.hive_sync.metastore.uris", "thrift://hive-metastore:9083").
+  mode(Overwrite).
+  save(basePath)
+System.exit(0)
+```
+
+:::note
+You will see a warning:
+
+```java
+WARN
+org.apache.hudi.metadata.HoodieBackedTableMetadata - 
+Metadata table was not found at path 
+s3a://huditest/hudi_coders/.hoodie/metadata
+```
+
+This can be ignored, the file will be created automatically during this `spark-shell` session.
+
+There will also be a warning:
+
+```bash
+78184 [main] WARN  org.apache.hadoop.fs.s3a.S3ABlockOutputStream  - 
+Application invoked the Syncable API against stream writing to 
+hudi_coders/.hoodie/metadata/files/.files-0000_00000000000000.log.1_0-0-0. 
+This is unsupported
+```
+
+This warning informs you that syncing a log file that is open for writes is not supported when using object storage. The file will only be synced when it is closed. See [Stack Overflow](https://stackoverflow.com/a/74886836/10424890).
+:::
+
+The final command in the above spark-shell session should exit the container, if it doesn't press enter and it will exit.
+
+## Configure StarRocks
+
+### Connect to StarRocks
+
+Connect to StarRocks with the provided MySQL client provided by the `starrocks-fe` service, or use your favorite SQL client and configure it to connect using the MySQL protocol on `localhost:9030`.
+
+```bash
+docker compose exec starrocks-fe \
+  mysql -P 9030 -h 127.0.0.1 -u root --prompt="StarRocks > "
+```
+
+### Create the linkage between StarRocks and Hudi
+
+There is a link at the end of this guide with more information on external catalogs. The external catalog created in this step acts as the linkage to the Hive Metastore (HMS) running in Docker.
+
+```sql
+CREATE EXTERNAL CATALOG hudi_catalog_hms
+PROPERTIES
+(
+    "type" = "hudi",
+    "hive.metastore.type" = "hive",
+    "hive.metastore.uris" = "thrift://hive-metastore:9083",
+    "aws.s3.use_instance_profile" = "false",
+    "aws.s3.access_key" = "admin",
+    "aws.s3.secret_key" = "password",
+    "aws.s3.enable_ssl" = "false",
+    "aws.s3.enable_path_style_access" = "true",
+    "aws.s3.endpoint" = "http://minio:9000"
+);
+```
+
+```plaintext
+Query OK, 0 rows affected (0.59 sec)
+```
+
+### Use the new catalog
+
+```sql
+SET CATALOG hudi_catalog_hms;
+```
+
+```plaintext
+Query OK, 0 rows affected (0.01 sec)
+```
+
+### Navigate to the data inserted with Spark
+
+```sql
+SHOW DATABASES;
+```
+
+```plaintext
++--------------------+
+| Database           |
++--------------------+
+| default            |
+| hudi_sample        |
+| information_schema |
++--------------------+
+2 rows in set (0.40 sec)
+```
+
+```sql
+USE hudi_sample;
+```
+
+```plaintext
+Reading table information for completion of table and column names
+You can turn off this feature to get a quicker startup with -A
+
+Database changed
+```
+
+```sql
+SHOW TABLES;
+```
+
+```plaintext
++-----------------------+
+| Tables_in_hudi_sample |
++-----------------------+
+| hudi_coders_hive      |
++-----------------------+
+1 row in set (0.07 sec)
+```
+
+### Query the data in Hudi with StarRocks
+
+Run this query twice, the first time may take around five seconds to complete as data is not yet cached in StarRocks. The second query will be very quick.
+
+```sql
+SELECT * from hudi_coders_hive\G
+```
+
+:::tip
+Some of the SQL queries in the StarRocks documentation end with `\G` instead
+of a semicolon. The `\G` causes the mysql CLI to render the query results vertically.
+
+Many SQL clients do not interpret vertical formatting output, so you should replace `\G` with `;` if you are not using the mysql CLI.
+:::
+
+```plaintext
+*************************** 1. row ***************************
+   _hoodie_commit_time: 20240208165522561
+  _hoodie_commit_seqno: 20240208165522561_0_0
+    _hoodie_record_key: c
+_hoodie_partition_path: language=Scala
+     _hoodie_file_name: bb29249a-b69d-4c32-843b-b7142d8dc51c-0_0-27-1221_20240208165522561.parquet
+              language: Scala
+                 users: 3000
+                    id: c
+*************************** 2. row ***************************
+   _hoodie_commit_time: 20240208165522561
+  _hoodie_commit_seqno: 20240208165522561_2_0
+    _hoodie_record_key: a
+_hoodie_partition_path: language=Java
+     _hoodie_file_name: 12fc14aa-7dc4-454c-b710-1ad0556c9386-0_2-27-1223_20240208165522561.parquet
+              language: Java
+                 users: 20000
+                    id: a
+*************************** 3. row ***************************
+   _hoodie_commit_time: 20240208165522561
+  _hoodie_commit_seqno: 20240208165522561_1_0
+    _hoodie_record_key: b
+_hoodie_partition_path: language=Python
+     _hoodie_file_name: 51977039-d71e-4dd6-90d4-0c93656dafcf-0_1-27-1222_20240208165522561.parquet
+              language: Python
+                 users: 100000
+                    id: b
+3 rows in set (0.15 sec)
+```
+
+## Summary
+
+This tutorial exposed you to the use of a StarRocks external catalog to show you that you can query your data where it sits using the Hudi external catalog. Many other integrations are available using Iceberg, Delta Lake, and JDBC catalogs.
+
+In this tutorial you:
+
+- Deployed StarRocks and a Hudi/Spark/MinIO environment in Docker
+- Loaded a tiny dataset into Hudi with Apache Spark
+- Configured a StarRocks external catalog to provide access to the Hudi catalog
+- Queried the data with SQL in StarRocks without copying the data from the data lake
+
+## More information
+
+[StarRocks Catalogs](../data_source/catalog/catalog_overview.md)
+
+[Apache Hudi quickstart](https://hudi.apache.org/docs/quick-start-guide/) (includes Spark)
+
+[Apache Hudi S3 configuration](https://hudi.apache.org/docs/s3_hoodie/)
+
+[Apache Spark configuration docs](https://spark.apache.org/docs/latest/configuration.html)

--- a/docs/en/quick_start/iceberg.md
+++ b/docs/en/quick_start/iceberg.md
@@ -1,0 +1,501 @@
+---
+displayed_sidebar: "English"
+sidebar_position: 3
+description: Data Lakehouse with Apache Iceberg
+toc_max_heading_level: 2
+---
+import DataLakeIntro from '../_assets/commonMarkdown/datalakeIntro.md'
+import Clients from '../_assets/quick-start/_clientsCompose.mdx'
+
+# Apache Iceberg Lakehouse
+
+## Overview
+
+- Deploy Object Storage, Apache Spark, Iceberg catalog, and StarRocks using Docker compose
+- Load New York City Green Taxi data for the month of May 2023 into the Iceberg data lake
+- Configure StarRocks to access the Iceberg catalog
+- Query the data with StarRocks where the data sits
+
+<DataLakeIntro />
+
+## Prerequisites
+
+### Docker
+
+- [Docker](https://docs.docker.com/engine/install/)
+- 5 GB RAM assigned to Docker
+- 20 GB free disk space assigned to Docker
+
+### SQL client
+
+You can use the SQL client provided in the Docker environment, or use one on your system. Many MySQL compatible clients will work, and this guide covers the configuration of DBeaver and MySQL WorkBench.
+
+### curl
+
+`curl` is used to download the datasets. Check to see if you have it installed by running `curl` or `curl.exe` at your OS prompt. If curl is not installed, [get curl here](https://curl.se/dlwiz/?type=bin).
+
+---
+
+## StarRocks terminology
+
+### FE
+
+Frontend nodes are responsible for metadata management, client connection management, query planning, and query scheduling. Each FE stores and maintains a complete copy of metadata in its memory, which guarantees indiscriminate services among the FEs.
+
+### BE
+
+Backend (BE) nodes are responsible for both data storage and executing query plans in shared-nothing deployments. When an external catalog (like the Iceberg catalog used in this guide) is used, the BE nodes can cache the data from the external catalog to accelerate queries.
+
+---
+
+## The environment
+
+There are six containers (services) used in this guide, and all are deployed with Docker compose. The services and their responsibilities are:
+
+| Service             | Responsibilities                                                    |
+|---------------------|---------------------------------------------------------------------|
+| **`starrocks-fe`**  | Metadata management, client connections, query plans and scheduling |
+| **`starrocks-be`**  | Running query plans                                                 |
+| **`rest`** | Providing the Iceberg catalog (metadata service)                             |
+| **`spark-iceberg`** | An Apache Spark environment to run PySpark in                       |
+| **`mc`**            | MinIO configuration (MinIO command line client)                     |
+| **`minio`**         | MinIO Object Storage                                                |
+
+## Download the Docker configuration and NYC Green Taxi data
+
+In order to provide an environment with the three necessary containers StarRocks provides a Docker compose file.  Download the compose file and dataset with curl.
+
+The Docker compose file:
+
+```bash
+mkdir iceberg
+cd iceberg
+curl -O https://raw.githubusercontent.com/StarRocks/demo/master/documentation-samples/iceberg/docker-compose.yml
+```
+
+And the dataset:
+
+```bash
+curl -O https://raw.githubusercontent.com/StarRocks/demo/master/documentation-samples/iceberg/datasets/green_tripdata_2023-05.parquet
+```
+
+## Start the environment in Docker
+
+:::tip
+Run this command, and any other `docker compose` commands, from the directory containing the `docker-compose.yml` file.
+:::
+
+```bash
+docker compose up -d
+```
+
+```plaintext
+[+] Building 0.0s (0/0)                     docker:desktop-linux
+[+] Running 6/6
+ ✔ Container iceberg-rest   Started                         0.0s
+ ✔ Container minio          Started                         0.0s
+ ✔ Container starrocks-fe   Started                         0.0s
+ ✔ Container mc             Started                         0.0s
+ ✔ Container spark-iceberg  Started                         0.0s
+ ✔ Container starrocks-be   Started
+```
+
+## Check the status of the environment
+
+Check the progress of the services. It should take around 30 seconds for the FE and BE to become healthy.
+
+Run `docker compose ps` until the FE and BE show a status of `healthy`. The rest of the services do not have healthcheck configurations, but you will be interacting with them and will know whether or not they are working:
+
+:::tip
+If you have `jq` installed and prefer a shorter list from `docker compose ps` try:
+
+```bash
+docker compose ps --format json | jq '{Service: .Service, State: .State, Status: .Status}'
+```
+
+:::
+
+```bash
+docker compose ps
+```
+
+```bash
+SERVICE         CREATED         STATUS                   PORTS
+rest            4 minutes ago   Up 4 minutes             0.0.0.0:8181->8181/tcp
+mc              4 minutes ago   Up 4 minutes
+minio           4 minutes ago   Up 4 minutes             0.0.0.0:9000-9001->9000-9001/tcp
+spark-iceberg   4 minutes ago   Up 4 minutes             0.0.0.0:8080->8080/tcp, 0.0.0.0:8888->8888/tcp, 0.0.0.0:10000-10001->10000-10001/tcp
+starrocks-be    4 minutes ago   Up 4 minutes (healthy)   0.0.0.0:8040->8040/tcp
+starrocks-fe    4 minutes ago   Up 4 minutes (healthy)   0.0.0.0:8030->8030/tcp, 0.0.0.0:9020->9020/tcp, 0.0.0.0:9030->9030/tcp
+```
+
+---
+
+## PySpark
+
+There are several ways to interact with Iceberg, this guide uses PySpark. If you are not familiar
+with PySpark there is documentation linked from the More Information section, but every command
+that you need to run is provided below.
+
+### Green Taxi dataset
+
+Copy the data to the spark-iceberg container. This command will copy the dataset file to the `/opt/spark/` directory in the `spark-iceberg` service:
+
+```bash
+docker compose \
+cp green_tripdata_2023-05.parquet spark-iceberg:/opt/spark/
+```
+
+### Launch PySpark
+
+This command will connect to the `spark-iceberg` service and run the command `pyspark`:
+
+```bash
+docker compose exec -it spark-iceberg pyspark
+```
+
+```py
+Welcome to
+      ____              __
+     / __/__  ___ _____/ /__
+    _\ \/ _ \/ _ `/ __/  '_/
+   /__ / .__/\_,_/_/ /_/\_\   version 3.5.0
+      /_/
+
+Using Python version 3.9.18 (main, Nov  1 2023 11:04:44)
+Spark context Web UI available at http://6ad5cb0e6335:4041
+Spark context available as 'sc' (master = local[*], app id = local-1701967093057).
+SparkSession available as 'spark'.
+>>>
+```
+
+### Read the dataset into a dataframe
+
+A dataframe is park of Spark SQL, and provides a data structure similar to a database table or a spreadsheet.
+
+The Green Taxi data is provided by NYC Taxi and Limousine Commission in Parquet format. Load the file from the `/opt/spark` directory and inspect the first few records by SELECTing the first few columns of the first three rows of data. These commands should be run in the `pyspark` session. The commands:
+
+- Read the dataset file from disk into a dataframe named `df`
+- Display the schema of the Parquet file
+
+```py
+df = spark.read.parquet("/opt/spark/green_tripdata_2023-05.parquet")
+df.printSchema()
+```
+
+```plaintext
+root
+ |-- VendorID: integer (nullable = true)
+ |-- lpep_pickup_datetime: timestamp_ntz (nullable = true)
+ |-- lpep_dropoff_datetime: timestamp_ntz (nullable = true)
+ |-- store_and_fwd_flag: string (nullable = true)
+ |-- RatecodeID: long (nullable = true)
+ |-- PULocationID: integer (nullable = true)
+ |-- DOLocationID: integer (nullable = true)
+ |-- passenger_count: long (nullable = true)
+ |-- trip_distance: double (nullable = true)
+ |-- fare_amount: double (nullable = true)
+ |-- extra: double (nullable = true)
+ |-- mta_tax: double (nullable = true)
+ |-- tip_amount: double (nullable = true)
+ |-- tolls_amount: double (nullable = true)
+ |-- ehail_fee: double (nullable = true)
+ |-- improvement_surcharge: double (nullable = true)
+ |-- total_amount: double (nullable = true)
+ |-- payment_type: long (nullable = true)
+ |-- trip_type: long (nullable = true)
+ |-- congestion_surcharge: double (nullable = true)
+
+>>>
+```
+
+Examine the first few (seven) columns of the first few (three) rows of data:
+
+```python
+df.select(df.columns[:7]).show(3)
+```
+
+```plaintext
++--------+--------------------+---------------------+------------------+----------+------------+------------+
+|VendorID|lpep_pickup_datetime|lpep_dropoff_datetime|store_and_fwd_flag|RatecodeID|PULocationID|DOLocationID|
++--------+--------------------+---------------------+------------------+----------+------------+------------+
+|       2| 2023-05-01 00:52:10|  2023-05-01 01:05:26|                 N|         1|         244|         213|
+|       2| 2023-05-01 00:29:49|  2023-05-01 00:50:11|                 N|         1|          33|         100|
+|       2| 2023-05-01 00:25:19|  2023-05-01 00:32:12|                 N|         1|         244|         244|
++--------+--------------------+---------------------+------------------+----------+------------+------------+
+only showing top 3 rows
+```
+
+### Write to a table
+
+The table created in this step will be in the catalog that will be made available in StarRocks in the next step.
+
+- Catalog: `demo`
+- Database: `nyc`
+- Table: `greentaxis`
+
+```python
+df.writeTo("demo.nyc.greentaxis").create()
+```
+
+## Configure StarRocks to access the Iceberg Catalog
+
+You can exit from PySpark now, or you can open a new terminal to run the SQL commands. If you do open a new terminal change your directory into the `quickstart` directory that contains the `docker-compose.yml` file before continuing.
+
+### Connect to StarRocks with a SQL client
+
+#### SQL Clients
+
+<Clients />
+
+---
+
+You can now exit the PySpark session and connect to StarRocks.
+
+:::tip
+
+Run this command from the directory containing the `docker-compose.yml` file.
+
+If you are using a client other than the mysql CLI, open that now.
+:::
+
+```bash
+docker compose exec starrocks-fe \
+  mysql -P 9030 -h 127.0.0.1 -u root --prompt="StarRocks > "
+```
+
+```plaintext
+StarRocks >
+```
+
+### Create an external catalog
+
+The external catalog is the configuration that allows StarRocks to operate on
+the Iceberg data as if it was in StarRocks databases and tables. The individual 
+configuration properties will be detailed after the command.
+
+```sql
+CREATE EXTERNAL CATALOG 'iceberg'
+PROPERTIES
+(
+  "type"="iceberg",
+  "iceberg.catalog.type"="rest",
+  "iceberg.catalog.uri"="http://iceberg-rest:8181",
+  "iceberg.catalog.warehouse"="warehouse",
+  "aws.s3.access_key"="admin",
+  "aws.s3.secret_key"="password",
+  "aws.s3.endpoint"="http://minio:9000",
+  "aws.s3.enable_path_style_access"="true",
+  "client.factory"="com.starrocks.connector.iceberg.IcebergAwsClientFactory"
+);
+```
+
+#### PROPERTIES
+
+|    Property                      |     Description                                                                               |
+|:---------------------------------|:----------------------------------------------------------------------------------------------|
+|`type`                            | In this example the type is `iceberg`. Other options include Hive, Hudi, Delta Lake, and JDBC.|
+|`iceberg.catalog.type`            | In this example `rest` is used. Tabular provides the Docker image used and Tabular uses REST.|
+|`iceberg.catalog.uri`             | The REST server endpoint.|
+|`iceberg.catalog.warehouse`       | The identifier of the Iceberg catalog. In this case the warehouse name specified in the compose file is `warehouse`. |
+|`aws.s3.access_key`               | The MinIO key. In this case the key and password are set in the compose file to `admin` |
+|`aws.s3.secret_key`               | and `password`. |
+|`aws.s3.endpoint`                 | The MinIO endpoint. |
+|`aws.s3.enable_path_style_access` | When using MinIO for Object Storage this is required. MinIO expects this format `http://host:port/<bucket_name>/<key_name>` |
+|`client.factory`                  | By setting this property to use `iceberg.IcebergAwsClientFactory` the `aws.s3.access_key` and `aws.s3.secret_key` parameters are used for authentication. |
+
+```sql
+SHOW CATALOGS;
+```
+
+```plaintext
++-----------------+----------+------------------------------------------------------------------+
+| Catalog         | Type     | Comment                                                          |
++-----------------+----------+------------------------------------------------------------------+
+| default_catalog | Internal | An internal catalog contains this cluster's self-managed tables. |
+| iceberg         | Iceberg  | NULL                                                             |
++-----------------+----------+------------------------------------------------------------------+
+2 rows in set (0.03 sec)
+```
+
+```sql
+SET CATALOG iceberg;
+```
+
+```sql
+SHOW DATABASES;
+```
+
+:::tip
+The database that you see was created in your PySpark
+session. When you added the CATALOG `iceberg`, the 
+database `nyc` became visible in StarRocks.
+:::
+
+```plaintext
++----------+
+| Database |
++----------+
+| nyc      |
++----------+
+1 row in set (0.07 sec)
+```
+
+```sql
+USE nyc;
+```
+
+```plaintext
+Reading table information for completion of table and column names
+You can turn off this feature to get a quicker startup with -A
+
+Database changed
+```
+
+```sql
+SHOW TABLES;
+```
+
+```plaintext
++---------------+
+| Tables_in_nyc |
++---------------+
+| greentaxis    |
++---------------+
+1 rows in set (0.05 sec)
+```
+
+```sql
+DESCRIBE greentaxis;
+```
+
+:::tip
+Compare the schema that StarRocks uses with the output of `df.printSchema()` from the earlier PySpark session. The Spark `timestamp_ntz` data types are represented as StarRocks `DATETIME` etc.
+:::
+
+```plaintext
++-----------------------+------------------+------+-------+---------+-------+
+| Field                 | Type             | Null | Key   | Default | Extra |
++-----------------------+------------------+------+-------+---------+-------+
+| VendorID              | INT              | Yes  | false | NULL    |       |
+| lpep_pickup_datetime  | DATETIME         | Yes  | false | NULL    |       |
+| lpep_dropoff_datetime | DATETIME         | Yes  | false | NULL    |       |
+| store_and_fwd_flag    | VARCHAR(1048576) | Yes  | false | NULL    |       |
+| RatecodeID            | BIGINT           | Yes  | false | NULL    |       |
+| PULocationID          | INT              | Yes  | false | NULL    |       |
+| DOLocationID          | INT              | Yes  | false | NULL    |       |
+| passenger_count       | BIGINT           | Yes  | false | NULL    |       |
+| trip_distance         | DOUBLE           | Yes  | false | NULL    |       |
+| fare_amount           | DOUBLE           | Yes  | false | NULL    |       |
+| extra                 | DOUBLE           | Yes  | false | NULL    |       |
+| mta_tax               | DOUBLE           | Yes  | false | NULL    |       |
+| tip_amount            | DOUBLE           | Yes  | false | NULL    |       |
+| tolls_amount          | DOUBLE           | Yes  | false | NULL    |       |
+| ehail_fee             | DOUBLE           | Yes  | false | NULL    |       |
+| improvement_surcharge | DOUBLE           | Yes  | false | NULL    |       |
+| total_amount          | DOUBLE           | Yes  | false | NULL    |       |
+| payment_type          | BIGINT           | Yes  | false | NULL    |       |
+| trip_type             | BIGINT           | Yes  | false | NULL    |       |
+| congestion_surcharge  | DOUBLE           | Yes  | false | NULL    |       |
++-----------------------+------------------+------+-------+---------+-------+
+20 rows in set (0.04 sec)
+```
+
+:::tip
+Some of the SQL queries in the StarRocks documentation end with `\G` instead
+of a semicolon. The `\G` causes the mysql CLI to render the query results vertically.
+
+Many SQL clients do not interpret vertical formatting output, so you should replace `\G` with `;` if you are not using the mysql CLI.
+:::
+
+## Query with StarRocks
+
+### Verify pickup datetime format
+
+```sql
+SELECT lpep_pickup_datetime FROM greentaxis LIMIT 10;
+```
+
+```plaintext
++----------------------+
+| lpep_pickup_datetime |
++----------------------+
+| 2023-05-01 00:52:10  |
+| 2023-05-01 00:29:49  |
+| 2023-05-01 00:25:19  |
+| 2023-05-01 00:07:06  |
+| 2023-05-01 00:43:31  |
+| 2023-05-01 00:51:54  |
+| 2023-05-01 00:27:46  |
+| 2023-05-01 00:27:14  |
+| 2023-05-01 00:24:14  |
+| 2023-05-01 00:46:55  |
++----------------------+
+10 rows in set (0.07 sec)
+```
+
+#### Find the busy hours
+
+This query aggregates the trips on the hour of the day and shows that
+the busiest hour of the day is 18:00.
+
+```sql
+SELECT COUNT(*) AS trips,
+       hour(lpep_pickup_datetime) AS hour_of_day
+FROM greentaxis
+GROUP BY hour_of_day
+ORDER BY trips DESC;
+```
+
+```plaintext
++-------+-------------+
+| trips | hour_of_day |
++-------+-------------+
+|  5381 |          18 |
+|  5253 |          17 |
+|  5091 |          16 |
+|  4736 |          15 |
+|  4393 |          14 |
+|  4275 |          19 |
+|  3893 |          12 |
+|  3816 |          11 |
+|  3685 |          13 |
+|  3616 |           9 |
+|  3530 |          10 |
+|  3361 |          20 |
+|  3315 |           8 |
+|  2917 |          21 |
+|  2680 |           7 |
+|  2322 |          22 |
+|  1735 |          23 |
+|  1202 |           6 |
+|  1189 |           0 |
+|   806 |           1 |
+|   606 |           2 |
+|   513 |           3 |
+|   451 |           5 |
+|   408 |           4 |
++-------+-------------+
+24 rows in set (0.08 sec)
+```
+
+---
+
+## Summary
+
+This tutorial exposed you to the use of a StarRocks external catalog to show you that you can query your data where it sits using the Iceberg REST catalog. Many other integrations are available using Hive, Hudi, Delta Lake, and JDBC catalogs.
+
+In this tutorial you:
+
+- Deployed StarRocks and an Iceberg/PySpark/MinIO environment in Docker
+- Configured a StarRocks external catalog to provide access to the Iceberg catalog
+- Loaded taxi data provided by New York City into the Iceberg data lake
+- Queried the data with SQL in StarRocks without copying the data from the data lake
+
+## More information
+
+[StarRocks Catalogs](../data_source/catalog/catalog_overview.md)
+
+[Apache Iceberg documentation](https://iceberg.apache.org/docs/latest/) and [Quickstart (includes PySpark)](https://iceberg.apache.org/spark-quickstart/)
+
+The [Green Taxi Trip Records](https://www.nyc.gov/site/tlc/about/tlc-trip-record-data.page) dataset is provided by New York City subject to these [terms of use](https://www.nyc.gov/home/terms-of-use.page) and [privacy policy](https://www.nyc.gov/home/privacy-policy.page).

--- a/docs/en/quick_start/quick_start.mdx
+++ b/docs/en/quick_start/quick_start.mdx
@@ -1,0 +1,14 @@
+---
+displayed_sidebar: "English"
+description: Deploy StarRocks with Docker Compose, Helm, and StarRocks Operator
+---
+
+# Quick Start
+
+These quick start guides will help you get going with a small StarRocks environment. The clusters that you will launch will be suitable for learning how StarRocks works, but are not meant for analyzing large datasets or performance testing.
+
+For scalable deployments please see [deploying StarRocks](../deployment/deployment_overview.md)
+
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />

--- a/docs/en/quick_start/routine-load.md
+++ b/docs/en/quick_start/routine-load.md
@@ -1,0 +1,692 @@
+---
+displayed_sidebar: "English"
+sidebar_position: 2
+toc_max_heading_level: 2
+description: Kafka routine load with shared-data storage
+keywords: ['Routine Load']
+---
+
+# Kafka routine load StarRocks using shared-data storage
+
+import Clients from '../_assets/quick-start/_clientsCompose.mdx'
+import SQL from '../_assets/quick-start/_SQL.mdx'
+
+## About Routine Load
+
+Routine load is a method using Apache Kafka, or in this lab, Redpanda, to continuously stream data into StarRocks. The data is streamed into a Kafka topic, and a Routine Load job consumes the data into StarRocks. More details on Routine Load are provided at the end of the lab.
+
+## About shared-data
+
+In systems that separate storage from compute, data is stored in low-cost reliable remote storage systems such as Amazon S3, Google Cloud Storage, Azure Blob Storage, and other S3-compatible storage like MinIO. Hot data is cached locally and when the cache is hit, the query performance is comparable to that of storage-compute coupled architecture. Compute nodes (CN) can be added or removed on demand within seconds. This architecture reduces storage costs, ensures better resource isolation, and provides elasticity and scalability.
+
+This tutorial covers:
+
+- Running StarRocks, Redpanda, and MinIO with Docker Compose
+- Using MinIO as the StarRocks storage layer
+- Configuring StarRocks for shared-data
+- Adding a Routine Load job to consume data from Redpanda
+
+The data used is synthetic.
+
+There is a lot of information in this document, and it is presented with step-by-step content at the beginning, and the technical details at the end. This is done to serve these purposes in this order:
+
+1. Configure Routine Load.
+2. Allow the reader to load data in a shared-data deployment and analyze that data.
+3. Provide the configuration details for shared-data deployments.
+
+---
+
+## Prerequisites
+
+### Docker
+
+- [Docker](https://docs.docker.com/engine/install/)
+- 4 GB RAM assigned to Docker
+- 10 GB free disk space assigned to Docker
+
+### SQL client
+
+You can use the SQL client provided in the Docker environment, or use one on your system. Many MySQL-compatible clients will work, and this guide covers the configuration of DBeaver and MySQL WorkBench.
+
+### curl
+
+`curl` is used to download the Compose file and the script to generate the data. Check to see if you have it installed by running `curl` or `curl.exe` at your OS prompt. If curl is not installed, [get curl here](https://curl.se/dlwiz/?type=bin).
+
+### Python
+
+Python 3 and the Python client for Apache Kafka, `kafka-python`, are required.
+
+- [Python](https://www.python.org/)
+- [`kafka-python`](https://pypi.org/project/kafka-python/)
+
+---
+
+## Terminology
+
+### FE
+
+Frontend nodes are responsible for metadata management, client connection management, query planning, and query scheduling. Each FE stores and maintains a complete copy of metadata in its memory, which guarantees indiscriminate services among the FEs.
+
+### CN
+
+Compute Nodes are responsible for executing query plans in shared-data deployments.
+
+### BE
+
+Backend nodes are responsible for both data storage and executing query plans in shared-nothing deployments.
+
+:::note
+This guide does not use BEs, this information is included here so that you understand the difference between BEs and CNs.
+:::
+
+---
+
+## Launch StarRocks
+
+To run StarRocks with shared-data using Object Storage you need:
+
+- A frontend engine (FE)
+- A compute node (CN)
+- Object Storage
+
+This guide uses MinIO, which is S3 compatible Object Storage provider. MinIO is provided under the GNU Affero General Public License.
+
+### Download the lab files
+
+#### `docker-compose.yml`
+
+```bash
+mkdir routineload
+cd routineload
+curl -O https://raw.githubusercontent.com/StarRocks/demo/master/documentation-samples/routine-load-shared-data/docker-compose.yml
+```
+
+#### `gen.py`
+
+`gen.py` is a script that uses the Python client for Apache Kafka to publish (produce) data to a Kafka topic. The script has been written with the address and port of the Redpanda container.
+
+```bash
+curl -O https://raw.githubusercontent.com/StarRocks/demo/master/documentation-samples/routine-load-shared-data/gen.py
+```
+
+## Start StarRocks, MinIO, and Redpanda
+
+```bash
+docker compose up --detach --wait --wait-timeout 120
+```
+
+Check the progress of the services. It should take 30 seconds or more for the containers to become healthy. The `routineload-minio_mc-1` container will not show a health indicator, and it will exit once it is done configuring MinIO with the access key that StarRocks will use. Wait for `routineload-minio_mc-1` to exit with a `0` code and the rest of the services to be `Healthy`.
+
+Run `docker compose ps` until the services are healthy:
+
+```bash
+docker compose ps
+```
+
+```plaintext
+WARN[0000] /Users/droscign/routineload/docker-compose.yml: `version` is obsolete
+[+] Running 6/7
+ ✔ Network routineload_default       Crea...          0.0s
+ ✔ Container minio                   Healthy          5.6s
+ ✔ Container redpanda                Healthy          3.6s
+ ✔ Container redpanda-console        Healt...         1.1s
+ ⠧ Container routineload-minio_mc-1  Waiting          23.1s
+ ✔ Container starrocks-fe            Healthy          11.1s
+ ✔ Container starrocks-cn            Healthy          23.0s
+container routineload-minio_mc-1 exited (0)
+```
+
+---
+
+## Examine MinIO credentials
+
+In order to use MinIO for Object Storage with StarRocks, StarRocks needs a MinIO access key. The access key was generated during the startup of the Docker services. To help you better understand the way that StarRocks connects to MinIO you should verify that the key exists.
+
+### Open the MinIO web UI
+
+Browse to http://localhost:9001/access-keys The username and password are specified in the Docker compose file, and are `miniouser` and `miniopassword`. You should see that there is one access key. The Key is `AAAAAAAAAAAAAAAAAAAA`, you cannot see the secret in the MinIO Console, but it is in the Docker compose file and is `BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB`:
+
+![View the MinIO access key](../_assets/quick-start/MinIO-view-key.png)
+
+---
+
+## SQL Clients
+
+<Clients />
+---
+
+## StarRocks configuration for shared-data
+
+At this point you have StarRocks, Redpanda, and MinIO running. A MinIO access key is used to connect StarRocks and Minio. When StarRocks started up, it established the connection with MinIO and created the default storage volume in MinIO.
+
+This is the configuration used to set the default storage volume to use MinIO (this is also in the Docker compose file). The configuration will be described in detail at the end of this guide, for now just note that the `aws_s3_access_key` is set to the string that you saw in the MinIO Console and that the `run_mode` is set to `shared_data`.
+
+```plaintext
+#highlight-start
+# enable shared data, set storage type, set endpoint
+run_mode = shared_data
+#highlight-end
+cloud_native_storage_type = S3
+aws_s3_endpoint = minio:9000
+
+# set the path in MinIO
+aws_s3_path = starrocks
+
+#highlight-start
+# credentials for MinIO object read/write
+aws_s3_access_key = AAAAAAAAAAAAAAAAAAAA
+aws_s3_secret_key = BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB
+#highlight-end
+aws_s3_use_instance_profile = false
+aws_s3_use_aws_sdk_default_behavior = false
+
+# Set this to false if you do not want default
+# storage created in the object storage using
+# the details provided above
+enable_load_volume_from_conf = true
+```
+
+:::tip
+
+To see the full configuration file you can run this command:
+
+```bash
+docker compose exec starrocks-fe cat fe/conf/fe.conf
+```
+
+Run all `docker compose` commands from the directory containing the `docker-compose.yml` file.
+
+:::
+
+### Connect to StarRocks with a SQL client
+
+:::tip
+
+Run this command from the directory containing the `docker-compose.yml` file.
+
+If you are using a client other than the mysql CLI, open that now.
+:::
+
+```sql
+docker compose exec starrocks-fe \
+mysql -P9030 -h127.0.0.1 -uroot --prompt="StarRocks > "
+```
+
+#### Examine the storage volume
+
+```sql
+SHOW STORAGE VOLUMES;
+```
+
+```plaintext
++------------------------+
+| Storage Volume         |
++------------------------+
+| builtin_storage_volume |
++------------------------+
+1 row in set (0.00 sec)
+```
+
+```sql
+DESC STORAGE VOLUME builtin_storage_volume\G
+```
+
+:::tip
+Some of the SQL in this document, and many other documents in the StarRocks documentation, and with `\G` instead
+of a semicolon. The `\G` causes the mysql CLI to render the query results vertically.
+
+Many SQL clients do not interpret vertical formatting output, so you should replace `\G` with `;`.
+:::
+
+```plaintext
+*************************** 1. row ***************************
+     Name: builtin_storage_volume
+     Type: S3
+IsDefault: true
+#highlight-start
+ Location: s3://starrocks
+   Params: {"aws.s3.access_key":"******","aws.s3.secret_key":"******","aws.s3.endpoint":"minio:9000","aws.s3.region":"","aws.s3.use_instance_profile":"false","aws.s3.use_aws_sdk_default_behavior":"false"}
+#highlight-end
+  Enabled: true
+  Comment:
+1 row in set (0.03 sec)
+```
+
+Verify that the parameters match the configuration.
+
+:::note
+The folder `builtin_storage_volume` will not be visible in the MinIO object list until data is written to the bucket.
+:::
+
+---
+
+## Create a table
+
+These SQL commands are run in your SQL client.
+
+```SQL
+CREATE DATABASE quickstart;
+```
+
+```SQL
+USE quickstart;
+```
+
+```SQL
+CREATE TABLE site_clicks (
+    `uid` bigint NOT NULL COMMENT "uid",
+    `site` string NOT NULL COMMENT "site url",
+    `vtime` bigint NOT NULL COMMENT "vtime"
+)
+DISTRIBUTED BY HASH(`uid`)
+PROPERTIES("replication_num"="1");
+```
+
+---
+
+### Open the Redpanda Console
+
+There will be no topics yet, a topic will be created in the next step.
+
+http://localhost:8080/overview
+
+### Publish data to a Redpanda topic
+
+From a command shell in the `routineload/` folder run this command to generate data:
+
+```python
+python gen.py 5
+```
+
+:::tip
+
+On your system, you might need to use `python3` in place of `python` in the command.
+
+If you are missing `kafka-python` try:
+
+```
+pip install kafka-python
+```
+ or
+
+```
+pip3 install kafka-python
+```
+
+:::
+
+```plaintext
+b'{ "uid": 6926, "site": "https://docs.starrocks.io/", "vtime": 1718034793 } '
+b'{ "uid": 3303, "site": "https://www.starrocks.io/product/community", "vtime": 1718034793 } '
+b'{ "uid": 227, "site": "https://docs.starrocks.io/", "vtime": 1718034243 } '
+b'{ "uid": 7273, "site": "https://docs.starrocks.io/", "vtime": 1718034794 } '
+b'{ "uid": 4666, "site": "https://www.starrocks.io/", "vtime": 1718034794 } '
+```
+
+### Verify in the Redpanda Console
+
+Navigate to http://localhost:8080/topics in the Redpanda Console, and you will see one topic named `test2`. Select that topic and then the **Messages** tab and you will see five messages matching the output of `gen.py`.
+
+## Consume the messages
+
+In StarRocks you will create a Routine Load job to:
+
+1. Consume the messages from the Redpanda topic `test2`
+2. Load those messages into the table `site_clicks`
+
+StarRocks is configured to use MinIO for storage, so the data inserted into the `site_clicks` table will be stored in MinIO.
+
+### Create a Routine Load job
+
+Run this command in the SQL client to create the Routine Load job, the command will be explained in detail at the end of the lab.
+
+```SQL
+CREATE ROUTINE LOAD quickstart.clicks ON site_clicks
+PROPERTIES
+(
+    "format" = "JSON",
+    "jsonpaths" ="[\"$.uid\",\"$.site\",\"$.vtime\"]"
+)
+FROM KAFKA
+(     
+    "kafka_broker_list" = "redpanda:29092",
+    "kafka_topic" = "test2",
+    "kafka_partitions" = "0",
+    "kafka_offsets" = "OFFSET_BEGINNING"
+);
+```
+
+### Verify the Routine Load job
+
+```SQL
+SHOW ROUTINE LOAD\G
+```
+
+Verify the three highlighted lines:
+
+1. The state should be `RUNNING`
+2. The topic should be `test2` and the broker should be `redpanda:2092`
+3. The statistics should show either 0 or 5 loaded rows depending on how soon you ran the `SHOW ROUTINE LOAD` command. If there are 0 loaded rows run it again.
+
+```SQL
+*************************** 1. row ***************************
+                  Id: 10078
+                Name: clicks
+          CreateTime: 2024-06-12 15:51:12
+           PauseTime: NULL
+             EndTime: NULL
+              DbName: quickstart
+           TableName: site_clicks
+           -- highlight-next-line
+               State: RUNNING
+      DataSourceType: KAFKA
+      CurrentTaskNum: 1
+       JobProperties: {"partitions":"*","partial_update":"false","columnToColumnExpr":"*","maxBatchIntervalS":"10","partial_update_mode":"null","whereExpr":"*","dataFormat":"json","timezone":"Etc/UTC","format":"json","log_rejected_record_num":"0","taskTimeoutSecond":"60","json_root":"","maxFilterRatio":"1.0","strict_mode":"false","jsonpaths":"[\"$.uid\",\"$.site\",\"$.vtime\"]","taskConsumeSecond":"15","desireTaskConcurrentNum":"5","maxErrorNum":"0","strip_outer_array":"false","currentTaskConcurrentNum":"1","maxBatchRows":"200000"}
+       -- highlight-next-line
+DataSourceProperties: {"topic":"test2","currentKafkaPartitions":"0","brokerList":"redpanda:29092"}
+    CustomProperties: {"group.id":"clicks_ea38a713-5a0f-4abe-9b11-ff4a241ccbbd"}
+    -- highlight-next-line
+           Statistic: {"receivedBytes":0,"errorRows":0,"committedTaskNum":0,"loadedRows":0,"loadRowsRate":0,"abortedTaskNum":0,"totalRows":0,"unselectedRows":0,"receivedBytesRate":0,"taskExecuteTimeMs":1}
+            Progress: {"0":"OFFSET_ZERO"}
+   TimestampProgress: {}
+ReasonOfStateChanged:
+        ErrorLogUrls:
+         TrackingSQL:
+            OtherMsg:
+LatestSourcePosition: {}
+1 row in set (0.00 sec)
+```
+
+```SQL
+SHOW ROUTINE LOAD\G
+```
+
+```SQL
+*************************** 1. row ***************************
+                  Id: 10076
+                Name: clicks
+          CreateTime: 2024-06-12 18:40:53
+           PauseTime: NULL
+             EndTime: NULL
+              DbName: quickstart
+           TableName: site_clicks
+               State: RUNNING
+      DataSourceType: KAFKA
+      CurrentTaskNum: 1
+       JobProperties: {"partitions":"*","partial_update":"false","columnToColumnExpr":"*","maxBatchIntervalS":"10","partial_update_mode":"null","whereExpr":"*","dataFormat":"json","timezone":"Etc/UTC","format":"json","log_rejected_record_num":"0","taskTimeoutSecond":"60","json_root":"","maxFilterRatio":"1.0","strict_mode":"false","jsonpaths":"[\"$.uid\",\"$.site\",\"$.vtime\"]","taskConsumeSecond":"15","desireTaskConcurrentNum":"5","maxErrorNum":"0","strip_outer_array":"false","currentTaskConcurrentNum":"1","maxBatchRows":"200000"}
+DataSourceProperties: {"topic":"test2","currentKafkaPartitions":"0","brokerList":"redpanda:29092"}
+    CustomProperties: {"group.id":"clicks_a9426fee-45bb-403a-a1a3-b3bc6c7aa685"}
+               -- highlight-next-line
+           Statistic: {"receivedBytes":372,"errorRows":0,"committedTaskNum":1,"loadedRows":5,"loadRowsRate":0,"abortedTaskNum":0,"totalRows":5,"unselectedRows":0,"receivedBytesRate":0,"taskExecuteTimeMs":519}
+            Progress: {"0":"4"}
+   TimestampProgress: {"0":"1718217035111"}
+ReasonOfStateChanged:
+        ErrorLogUrls:
+         TrackingSQL:
+            OtherMsg:
+                       -- highlight-next-line
+LatestSourcePosition: {"0":"5"}
+1 row in set (0.00 sec)
+```
+
+---
+
+## Verify that data is stored in MinIO
+
+Open MinIO [http://localhost:9001/browser/](http://localhost:9001/browser/) and verify that there are objects stored under `starrocks`.
+
+---
+
+## Query the data from StarRocks
+
+```SQL
+USE quickstart;
+SELECT * FROM site_clicks;
+```
+
+```SQL
++------+--------------------------------------------+------------+
+| uid  | site                                       | vtime      |
++------+--------------------------------------------+------------+
+| 4607 | https://www.starrocks.io/blog              | 1718031441 |
+| 1575 | https://www.starrocks.io/                  | 1718031523 |
+| 2398 | https://docs.starrocks.io/                 | 1718033630 |
+| 3741 | https://www.starrocks.io/product/community | 1718030845 |
+| 4792 | https://www.starrocks.io/                  | 1718033413 |
++------+--------------------------------------------+------------+
+5 rows in set (0.07 sec)
+```
+
+## Publish additional data
+
+Running `gen.py` again will publish another five records to Redpanda.
+
+```bash
+python gen.py 5
+```
+
+### Verify that data is added
+
+Since the Routine Load job runs on a schedule (every 10 seconds by default), the data will be loaded within a few seconds.
+
+```SQL
+SELECT * FROM site_clicks;
+````
+
+```
++------+--------------------------------------------+------------+
+| uid  | site                                       | vtime      |
++------+--------------------------------------------+------------+
+| 6648 | https://www.starrocks.io/blog              | 1718205970 |
+| 7914 | https://www.starrocks.io/                  | 1718206760 |
+| 9854 | https://www.starrocks.io/blog              | 1718205676 |
+| 1186 | https://www.starrocks.io/                  | 1718209083 |
+| 3305 | https://docs.starrocks.io/                 | 1718209083 |
+| 2288 | https://www.starrocks.io/blog              | 1718206759 |
+| 7879 | https://www.starrocks.io/product/community | 1718204280 |
+| 2666 | https://www.starrocks.io/                  | 1718208842 |
+| 5801 | https://www.starrocks.io/                  | 1718208783 |
+| 8409 | https://www.starrocks.io/                  | 1718206889 |
++------+--------------------------------------------+------------+
+10 rows in set (0.02 sec)
+```
+
+---
+
+## Configuration details
+
+Now that you have experienced using StarRocks with shared-data it is important to understand the configuration. 
+
+### CN configuration
+
+The CN configuration used here is the default, as the CN is designed for shared-data use. The default configuration is shown below. You do not need to make any changes.
+
+```bash
+sys_log_level = INFO
+
+# ports for admin, web, heartbeat service
+be_port = 9060
+be_http_port = 8040
+heartbeat_service_port = 9050
+brpc_port = 8060
+starlet_port = 9070
+```
+
+### FE configuration
+
+The FE configuration is slightly different from the default as the FE must be configured to expect that data is stored in Object Storage rather than on local disks on BE nodes.
+
+The `docker-compose.yml` file generates the FE configuration in the `command` section of the `starrocks-fe` service.
+
+```plaintext
+# enable shared data, set storage type, set endpoint
+run_mode = shared_data
+cloud_native_storage_type = S3
+aws_s3_endpoint = minio:9000
+
+# set the path in MinIO
+aws_s3_path = starrocks
+
+# credentials for MinIO object read/write
+aws_s3_access_key = AAAAAAAAAAAAAAAAAAAA
+aws_s3_secret_key = BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB
+aws_s3_use_instance_profile = false
+aws_s3_use_aws_sdk_default_behavior = false
+
+# Set this to false if you do not want default
+# storage created in the object storage using
+# the details provided above
+enable_load_volume_from_conf = true
+```
+
+:::note
+This config file does not contain the default entries for an FE, only the shared-data configuration is shown.
+:::
+
+The non-default FE configuration settings:
+
+:::note
+Many configuration parameters are prefixed with `s3_`. This prefix is used for all Amazon S3 compatible storage types (for example: S3, GCS, and MinIO). When using Azure Blob Storage the prefix is `azure_`.
+:::
+
+#### `run_mode=shared_data`
+
+This enables shared-data use.
+
+#### `cloud_native_storage_type=S3`
+
+This specifies whether S3 compatible storage or Azure Blob Storage is used. For MinIO this is always S3.
+
+#### `aws_s3_endpoint=minio:9000`
+
+The MinIO endpoint, including port number.
+
+#### `aws_s3_path=starrocks`
+
+The bucket name.
+
+#### `aws_s3_access_key=AAAAAAAAAAAAAAAAAAAA`
+
+The MinIO access key.
+
+#### `aws_s3_secret_key=BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB`
+
+The MinIO access key secret.
+
+#### `aws_s3_use_instance_profile=false`
+
+When using MinIO an access key is used, and so instance profiles are not used with MinIO.
+
+#### `aws_s3_use_aws_sdk_default_behavior=false`
+
+When using MinIO this parameter is always set to false.
+
+#### `enable_load_volume_from_conf=true`
+
+When this is true, a StarRocks storage volume named `builtin_storage_volume` is created using MinIO object storage, and it is set to be the default storage volume for the tables that you create.
+
+---
+
+## Notes on the Routine Load command
+
+StarRocks Routine Load takes many arguments. Only the ones used in this tutorial are described here, the rest will be linked to in the more information section.
+
+```SQL
+CREATE ROUTINE LOAD quickstart.clicks ON site_clicks
+PROPERTIES
+(
+    "format" = "JSON",
+    "jsonpaths" ="[\"$.uid\",\"$.site\",\"$.vtime\"]"
+)
+FROM KAFKA
+(     
+    "kafka_broker_list" = "redpanda:29092",
+    "kafka_topic" = "test2",
+    "kafka_partitions" = "0",
+    "kafka_offsets" = "OFFSET_BEGINNING"
+);
+```
+
+### Parameters
+
+```
+CREATE ROUTINE LOAD quickstart.clicks ON site_clicks
+```
+
+The parameters for `CREATE ROUTINE LOAD ON` are:
+- database_name.job_name
+- table_name
+
+`database_name` is optional. In this lab, it is `quickstart` and is specified.
+
+`job_name` is required, and is `clicks`
+
+`table_name` is required, and is `site_clicks`
+
+### Job properties
+
+#### Property `format`
+
+```
+"format" = "JSON",
+```
+
+In this case, the data is in JSON format, so the property is set to `JSON`. The other valid formats are: `CSV`, `JSON`, and `Avro`. `CSV` is the default.
+
+#### Property `jsonpaths`
+
+```
+"jsonpaths" ="[\"$.uid\",\"$.site\",\"$.vtime\"]"
+```
+
+The names of the fields that you want to load from JSON-formatted data. The value of this parameter is a valid JsonPath expression. More information is available at the end of this page.
+
+
+### Data source properties
+
+#### `kafka_broker_list`
+
+```
+"kafka_broker_list" = "redpanda:29092",
+```
+
+Kafka's broker connection information. The format is `<kafka_broker_name_or_ip>:<broker_ port>`. Multiple brokers are separated by commas.
+
+#### `kafka_topic`
+
+```
+"kafka_topic" = "test2",
+```
+
+The Kafka topic to consume from.
+
+#### `kafka_partitions` and `kafka_offsets`
+
+```
+"kafka_partitions" = "0",
+"kafka_offsets" = "OFFSET_BEGINNING"
+```
+
+These properties are presented together as there is one `kafka_offset` required for each `kafka_partitions` entry. 
+
+`kafka_partitions` is a list of one or more partitions to consume. If this property is not set, then all partitions are consumed.
+
+`kafka_offsets` is a list of offsets, one for each partition listed in `kafka_partitions`. In this case the value is `OFFSET_BEGINNING` which causes all of the data to be consumed. The default is to only consume new data.
+
+---
+
+## Summary
+
+In this tutorial you:
+
+- Deployed StarRocks, Reedpanda, and Minio in Docker
+- Created a Routine Load job to consume data from a Kafka topic
+- Learned how to configure a StarRocks Storage Volume that uses MinIO
+
+## More information
+
+[StarRocks Architecture](../introduction/Architecture.md)
+
+The sample used for this lab is very simple. Routine Load has many more options and capabilities. [learn more](../loading/RoutineLoad.md).
+
+[JSONPath](https://goessner.net/articles/JsonPath/)

--- a/docs/en/quick_start/shared-data.md
+++ b/docs/en/quick_start/shared-data.md
@@ -1,0 +1,515 @@
+---
+displayed_sidebar: "English"
+sidebar_position: 2
+description: Separate compute and storage
+---
+
+# Separate storage and compute
+
+import DDL from '../_assets/quick-start/_DDL.mdx'
+import Clients from '../_assets/quick-start/_clientsCompose.mdx'
+import SQL from '../_assets/quick-start/_SQL.mdx'
+import Curl from '../_assets/quick-start/_curl.mdx'
+
+In systems that separate storage from compute data is stored in low-cost reliable remote storage systems such as Amazon S3, Google Cloud Storage, Azure Blob Storage, and other S3-compatible storage like MinIO. Hot data is cached locally and When the cache is hit, the query performance is comparable to that of storage-compute coupled architecture. Compute nodes (CN) can be added or removed on demand within seconds. This architecture reduces storage cost, ensures better resource isolation, and provides elasticity and scalability.
+
+This tutorial covers:
+
+- Running StarRocks in Docker containers
+- Using MinIO for Object Storage
+- Configuring StarRocks for shared-data
+- Loading two public datasets
+- Analyzing the data with SELECT and JOIN
+- Basic data transformation (the **T** in ETL)
+
+The data used is provided by NYC OpenData and the National Centers for Environmental Information at NOAA.
+
+Both of these datasets are very large, and because this tutorial is intended to help you get exposed to working with StarRocks we are not going to load data for the past 120 years. You can run the Docker image and load this data on a machine with 4 GB RAM assigned to Docker. For larger fault-tolerant and scalable deployments we have other documentation and will provide that later.
+
+There is a lot of information in this document, and it is presented with the step by step content at the beginning, and the technical details at the end. This is done to serve these purposes in this order:
+
+1. Allow the reader to load data in a shared-data deployment and analyze that data.
+2. Provide the configuration details for shared-data deployments.
+3. Explain the basics of data transformation during loading.
+
+---
+
+## Prerequisites
+
+### Docker
+
+- [Docker](https://docs.docker.com/engine/install/)
+- 4 GB RAM assigned to Docker
+- 10 GB free disk space assigned to Docker
+
+### SQL client
+
+You can use the SQL client provided in the Docker environment, or use one on your system. Many MySQL compatible clients will work, and this guide covers the configuration of DBeaver and MySQL WorkBench.
+
+### curl
+
+`curl` is used to issue the data load job to StarRocks, and to download the datasets. Check to see if you have it installed by running `curl` or `curl.exe` at your OS prompt. If curl is not installed, [get curl here](https://curl.se/dlwiz/?type=bin).
+
+### `/etc/hosts`
+
+The ingest method used in this guide is Stream Load. Stream Load connects to the FE service to start the ingest job. The FE then assigns the job to a backend node, the CN in this guide. In order for the ingest job to connect to the CN the name of the CN must be available to your operating system. Add this line to `/etc/hosts`:
+
+```bash
+127.0.0.1 starrocks-cn
+```
+
+---
+
+## Terminology
+
+### FE
+
+Frontend nodes are responsible for metadata management, client connection management, query planning, and query scheduling. Each FE stores and maintains a complete copy of metadata in its memory, which guarantees indiscriminate services among the FEs.
+
+### CN
+
+Compute Nodes are responsible for executing query plans in shared-data deployments.
+
+### BE
+
+Backend nodes are responsible for both data storage and executing query plans in shared-nothing deployments.
+
+:::note
+This guide does not use BEs, this information is included here so that you understand the difference between BEs and CNs.
+:::
+
+---
+
+## Download the lab files
+
+There are three files to download:
+
+- The Docker Compose file that deploys the StarRocks and MinIO environment
+- New York City crash data
+- Weather data
+
+This guide uses MinIO, which is S3 compatible Object Storage provided under the GNU Affero General Public License.
+
+### Create a directory to store the lab files:
+
+```bash
+mkdir quickstart
+cd quickstart
+```
+
+### Download the Docker Compose file
+
+```bash
+curl -O https://raw.githubusercontent.com/StarRocks/demo/master/documentation-samples/quickstart/docker-compose.yml
+```
+
+### Download the data
+
+Download these two datasets:
+
+#### New York City crash data
+
+```bash
+curl -O https://raw.githubusercontent.com/StarRocks/demo/master/documentation-samples/quickstart/datasets/NYPD_Crash_Data.csv
+```
+
+#### Weather data
+
+```bash
+curl -O https://raw.githubusercontent.com/StarRocks/demo/master/documentation-samples/quickstart/datasets/72505394728.csv
+```
+
+---
+
+## Deploy StarRocks and MinIO
+
+```bash
+docker compose up --detach --wait --wait-timeout 120
+```
+
+It should take around 30 seconds for the FE, CN, and MinIO services to become healthy. The `quickstart-minio_mc-1` container will show a status of `Waiting` and also an exit code. An exit code of `0` indicates success.
+
+```bash
+[+] Running 4/5
+ ✔ Network quickstart_default       Created    0.0s
+ ✔ Container minio                  Healthy    6.8s
+ ✔ Container starrocks-fe           Healthy    29.3s
+ ⠼ Container quickstart-minio_mc-1  Waiting    29.3s
+ ✔ Container starrocks-cn           Healthy    29.2s
+container quickstart-minio_mc-1 exited (0)
+```
+
+---
+
+## Examine MinIO credentials
+
+To use MinIO for Object Storage with StarRocks, StarRocks needs a MinIO access key. The access key was generated during the startup of the Docker services. To help you better understand the way that StarRocks connects to MinIO you should verify that the key exists.
+
+### Open the MinIO web UI
+
+Browse to http://localhost:9001/access-keys The username and password are specified in the Docker compose file, and are `miniouser` and `miniopassword`. You should see that there is one access key. The Key is `AAAAAAAAAAAAAAAAAAAA`, you cannot see the secret in the MinIO Console, but it is in the Docker compose file and is `BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB`:
+
+![View the MinIO access key](../_assets/quick-start/MinIO-view-key.png)
+
+:::tip
+If there are no access keys showing in the MinIO web UI, check the logs of the `minio_mc` service:
+
+```bash
+docker compose logs minio_mc
+```
+
+Try rerunning the `minio_mc` pod:
+
+```bash
+docker compose run minio_mc
+```
+:::
+
+---
+
+## SQL Clients
+
+<Clients />
+
+---
+
+
+## StarRocks configuration for shared-data
+
+At this point you have StarRocks running, and you have MinIO running. The MinIO access key is used to connect StarRocks and Minio. When StarRocks started up it established the connection with MinIO and created the default storage volume in MinIO.
+
+This is the configuration used to set the default storage volume to use MinIO (this is also in the Docker compose file). The configuration will be described in detail at the end of this guide, for now just note that the `aws_s3_access_key` is set to the string that you saw in the MinIO Console and that the `run_mode` is set to `shared_data`:
+
+```plaintext
+#highlight-start
+# enable shared data, set storage type, set endpoint
+run_mode = shared_data
+#highlight-end
+cloud_native_storage_type = S3
+aws_s3_endpoint = minio:9000
+
+# set the path in MinIO
+aws_s3_path = starrocks
+
+#highlight-start
+# credentials for MinIO object read/write
+aws_s3_access_key = AAAAAAAAAAAAAAAAAAAA
+aws_s3_secret_key = BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB
+#highlight-end
+aws_s3_use_instance_profile = false
+aws_s3_use_aws_sdk_default_behavior = false
+
+# Set this to false if you do not want default
+# storage created in the object storage using
+# the details provided above
+enable_load_volume_from_conf = true
+```
+
+### Connect to StarRocks with a SQL client
+
+:::tip
+
+Run this command from the directory containing the `docker-compose.yml` file.
+
+If you are using a client other than the mysql CLI, open that now.
+:::
+
+```sql
+docker compose exec starrocks-fe \
+mysql -P9030 -h127.0.0.1 -uroot --prompt="StarRocks > "
+```
+
+#### Examine the storage volume
+
+```sql
+SHOW STORAGE VOLUMES;
+```
+
+```plaintext
++------------------------+
+| Storage Volume         |
++------------------------+
+| builtin_storage_volume |
++------------------------+
+1 row in set (0.00 sec)
+```
+
+```sql
+DESC STORAGE VOLUME builtin_storage_volume\G
+```
+
+:::tip
+Some of the SQL in this document, and many other documents in the StarRocks documentation, and with `\G` instead
+of a semicolon. The `\G` causes the mysql CLI to render the query results vertically.
+
+Many SQL clients do not interpret vertical formatting output, so you should replace `\G` with `;`.
+:::
+
+```plaintext
+*************************** 1. row ***************************
+     Name: builtin_storage_volume
+     Type: S3
+IsDefault: true
+#highlight-start
+ Location: s3://starrocks
+   Params: {"aws.s3.access_key":"******","aws.s3.secret_key":"******","aws.s3.endpoint":"minio:9000","aws.s3.region":"","aws.s3.use_instance_profile":"false","aws.s3.use_aws_sdk_default_behavior":"false"}
+#highlight-end
+  Enabled: true
+  Comment:
+1 row in set (0.03 sec)
+```
+
+Verify that the parameters match the configuration.
+
+:::note
+The folder `builtin_storage_volume` will not be visible in the MinIO object list until data is written to the bucket.
+:::
+
+---
+
+## Create some tables
+
+<DDL />
+
+---
+
+## Load two datasets
+
+There are many ways to load data into StarRocks. For this tutorial the simplest way is to use curl and StarRocks Stream Load.
+
+:::tip
+
+Run these curl commands from the directory where you downloaded the dataset.
+
+You will be prompted for a password. You probably have not assigned a password to the MySQL `root` user, so just hit enter.
+
+:::
+
+The `curl` commands look complex, but they are explained in detail at the end of the tutorial. For now, we recommend running the commands and running some SQL to analyze the data, and then reading about the data loading details at the end.
+
+### New York City collision data - Crashes
+
+```bash
+curl --location-trusted -u root             \
+    -T ./NYPD_Crash_Data.csv                \
+    -H "label:crashdata-0"                  \
+    -H "column_separator:,"                 \
+    -H "skip_header:1"                      \
+    -H "enclose:\""                         \
+    -H "max_filter_ratio:1"                 \
+    -H "columns:tmp_CRASH_DATE, tmp_CRASH_TIME, CRASH_DATE=str_to_date(concat_ws(' ', tmp_CRASH_DATE, tmp_CRASH_TIME), '%m/%d/%Y %H:%i'),BOROUGH,ZIP_CODE,LATITUDE,LONGITUDE,LOCATION,ON_STREET_NAME,CROSS_STREET_NAME,OFF_STREET_NAME,NUMBER_OF_PERSONS_INJURED,NUMBER_OF_PERSONS_KILLED,NUMBER_OF_PEDESTRIANS_INJURED,NUMBER_OF_PEDESTRIANS_KILLED,NUMBER_OF_CYCLIST_INJURED,NUMBER_OF_CYCLIST_KILLED,NUMBER_OF_MOTORIST_INJURED,NUMBER_OF_MOTORIST_KILLED,CONTRIBUTING_FACTOR_VEHICLE_1,CONTRIBUTING_FACTOR_VEHICLE_2,CONTRIBUTING_FACTOR_VEHICLE_3,CONTRIBUTING_FACTOR_VEHICLE_4,CONTRIBUTING_FACTOR_VEHICLE_5,COLLISION_ID,VEHICLE_TYPE_CODE_1,VEHICLE_TYPE_CODE_2,VEHICLE_TYPE_CODE_3,VEHICLE_TYPE_CODE_4,VEHICLE_TYPE_CODE_5" \
+    -XPUT http://localhost:8030/api/quickstart/crashdata/_stream_load
+```
+
+Here is the output of the above command. The first highlighted section shown what you should expect to see (OK and all but one row inserted). One row was filtered out because it does not contain the correct number of columns.
+
+```bash
+Enter host password for user 'root':
+{
+    "TxnId": 2,
+    "Label": "crashdata-0",
+    "Status": "Success",
+    # highlight-start
+    "Message": "OK",
+    "NumberTotalRows": 423726,
+    "NumberLoadedRows": 423725,
+    # highlight-end
+    "NumberFilteredRows": 1,
+    "NumberUnselectedRows": 0,
+    "LoadBytes": 96227746,
+    "LoadTimeMs": 1013,
+    "BeginTxnTimeMs": 21,
+    "StreamLoadPlanTimeMs": 63,
+    "ReadDataTimeMs": 563,
+    "WriteDataTimeMs": 870,
+    "CommitAndPublishTimeMs": 57,
+    # highlight-start
+    "ErrorURL": "http://starrocks-cn:8040/api/_load_error_log?file=error_log_da41dd88276a7bfc_739087c94262ae9f"
+    # highlight-end
+}%
+```
+
+If there was an error the output provides a URL to see the error messages. The error message also contains the backend node that the Stream Load job was assigned to (`starrocks-cn`). Because you added an entry for `starrocks-cn` to the `/etc/hosts` file, you should be able to nvigate to it and read the error message.
+
+Expand the summary for the content seen while developing this tutorial:
+
+<details>
+
+<summary>Reading error messages in the browser</summary>
+
+```bash
+Error: Value count does not match column count. Expect 29, but got 32.
+
+Column delimiter: 44,Row delimiter: 10.. Row: 09/06/2015,14:15,,,40.6722269,-74.0110059,"(40.6722269, -74.0110059)",,,"R/O 1 BEARD ST. ( IKEA'S 
+09/14/2015,5:30,BRONX,10473,40.814551,-73.8490955,"(40.814551, -73.8490955)",TORRY AVENUE                    ,NORTON AVENUE                   ,,0,0,0,0,0,0,0,0,Driver Inattention/Distraction,Unspecified,,,,3297457,PASSENGER VEHICLE,PASSENGER VEHICLE,,,
+```
+
+</details>
+
+### Weather data
+
+Load the weather dataset in the same manner as you loaded the crash data.
+
+```bash
+curl --location-trusted -u root             \
+    -T ./72505394728.csv                    \
+    -H "label:weather-0"                    \
+    -H "column_separator:,"                 \
+    -H "skip_header:1"                      \
+    -H "enclose:\""                         \
+    -H "max_filter_ratio:1"                 \
+    -H "columns: STATION, DATE, LATITUDE, LONGITUDE, ELEVATION, NAME, REPORT_TYPE, SOURCE, HourlyAltimeterSetting, HourlyDewPointTemperature, HourlyDryBulbTemperature, HourlyPrecipitation, HourlyPresentWeatherType, HourlyPressureChange, HourlyPressureTendency, HourlyRelativeHumidity, HourlySkyConditions, HourlySeaLevelPressure, HourlyStationPressure, HourlyVisibility, HourlyWetBulbTemperature, HourlyWindDirection, HourlyWindGustSpeed, HourlyWindSpeed, Sunrise, Sunset, DailyAverageDewPointTemperature, DailyAverageDryBulbTemperature, DailyAverageRelativeHumidity, DailyAverageSeaLevelPressure, DailyAverageStationPressure, DailyAverageWetBulbTemperature, DailyAverageWindSpeed, DailyCoolingDegreeDays, DailyDepartureFromNormalAverageTemperature, DailyHeatingDegreeDays, DailyMaximumDryBulbTemperature, DailyMinimumDryBulbTemperature, DailyPeakWindDirection, DailyPeakWindSpeed, DailyPrecipitation, DailySnowDepth, DailySnowfall, DailySustainedWindDirection, DailySustainedWindSpeed, DailyWeather, MonthlyAverageRH, MonthlyDaysWithGT001Precip, MonthlyDaysWithGT010Precip, MonthlyDaysWithGT32Temp, MonthlyDaysWithGT90Temp, MonthlyDaysWithLT0Temp, MonthlyDaysWithLT32Temp, MonthlyDepartureFromNormalAverageTemperature, MonthlyDepartureFromNormalCoolingDegreeDays, MonthlyDepartureFromNormalHeatingDegreeDays, MonthlyDepartureFromNormalMaximumTemperature, MonthlyDepartureFromNormalMinimumTemperature, MonthlyDepartureFromNormalPrecipitation, MonthlyDewpointTemperature, MonthlyGreatestPrecip, MonthlyGreatestPrecipDate, MonthlyGreatestSnowDepth, MonthlyGreatestSnowDepthDate, MonthlyGreatestSnowfall, MonthlyGreatestSnowfallDate, MonthlyMaxSeaLevelPressureValue, MonthlyMaxSeaLevelPressureValueDate, MonthlyMaxSeaLevelPressureValueTime, MonthlyMaximumTemperature, MonthlyMeanTemperature, MonthlyMinSeaLevelPressureValue, MonthlyMinSeaLevelPressureValueDate, MonthlyMinSeaLevelPressureValueTime, MonthlyMinimumTemperature, MonthlySeaLevelPressure, MonthlyStationPressure, MonthlyTotalLiquidPrecipitation, MonthlyTotalSnowfall, MonthlyWetBulb, AWND, CDSD, CLDD, DSNW, HDSD, HTDD, NormalsCoolingDegreeDay, NormalsHeatingDegreeDay, ShortDurationEndDate005, ShortDurationEndDate010, ShortDurationEndDate015, ShortDurationEndDate020, ShortDurationEndDate030, ShortDurationEndDate045, ShortDurationEndDate060, ShortDurationEndDate080, ShortDurationEndDate100, ShortDurationEndDate120, ShortDurationEndDate150, ShortDurationEndDate180, ShortDurationPrecipitationValue005, ShortDurationPrecipitationValue010, ShortDurationPrecipitationValue015, ShortDurationPrecipitationValue020, ShortDurationPrecipitationValue030, ShortDurationPrecipitationValue045, ShortDurationPrecipitationValue060, ShortDurationPrecipitationValue080, ShortDurationPrecipitationValue100, ShortDurationPrecipitationValue120, ShortDurationPrecipitationValue150, ShortDurationPrecipitationValue180, REM, BackupDirection, BackupDistance, BackupDistanceUnit, BackupElements, BackupElevation, BackupEquipment, BackupLatitude, BackupLongitude, BackupName, WindEquipmentChangeDate" \
+    -XPUT http://localhost:8030/api/quickstart/weatherdata/_stream_load
+```
+
+---
+
+## Verify that data is stored in MinIO
+
+Open MinIO [http://localhost:9001/browser/starrocks/](http://localhost:9001/browser/starrocks/) and verify that you have `data`, `metadata`, and `schema` entries in each of the directories under `starrocks/shared/`
+
+:::tip
+The folder names below `starrocks/shared/` are generated when you load the data. You should see a single directory below `shared`, and then two more below that. Inside each of those directories you will find the data, metadata, and schema entries.
+
+![MinIO object browser](../_assets/quick-start/MinIO-data.png)
+:::
+
+---
+
+## Answer some questions
+
+<SQL />
+
+---
+
+## Configuring StarRocks for shared-data
+
+Now that you have experienced using StarRocks with shared-data it is important to understand the configuration. 
+
+### CN configuration
+
+The CN configuration used here is the default, as the CN is designed for shared-data use. The default configuration is shown below. You do not need to make any changes.
+
+```bash
+sys_log_level = INFO
+
+# ports for admin, web, heartbeat service
+be_port = 9060
+be_http_port = 8040
+heartbeat_service_port = 9050
+brpc_port = 8060
+starlet_port = 9070
+```
+
+### FE configuration
+
+The FE configuration is slightly different from the default as the FE must be configured to expect that data is stored in Object Storage rather than on local disks on BE nodes.
+
+The `docker-compose.yml` file generates the FE configuration in the `command`.
+
+```plaintext
+# enable shared data, set storage type, set endpoint
+run_mode = shared_data
+cloud_native_storage_type = S3
+aws_s3_endpoint = minio:9000
+
+# set the path in MinIO
+aws_s3_path = starrocks
+
+# credentials for MinIO object read/write
+aws_s3_access_key = AAAAAAAAAAAAAAAAAAAA
+aws_s3_secret_key = BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB
+aws_s3_use_instance_profile = false
+aws_s3_use_aws_sdk_default_behavior = false
+
+# Set this to false if you do not want default
+# storage created in the object storage using
+# the details provided above
+enable_load_volume_from_conf = true
+```
+
+:::note
+This config file does not contain the default entries for an FE, only the shared-data configuration is shown.
+:::
+
+The non-default FE configuration settings:
+
+:::note
+Many configuration parameters are prefixed with `s3_`. This prefix is used for all Amazon S3 compatible storage types (for example: S3, GCS, and MinIO). When using Azure Blob Storage the prefix is `azure_`.
+:::
+
+#### `run_mode=shared_data`
+
+This enables shared-data use.
+
+#### `cloud_native_storage_type=S3`
+
+This specifies whether S3 compatible storage or Azure Blob Storage is used. For MinIO this is always S3.
+
+#### `aws_s3_endpoint=minio:9000`
+
+The MinIO endpoint, including port number.
+
+#### `aws_s3_path=starrocks`
+
+The bucket name.
+
+#### `aws_s3_access_key=AA`
+
+The MinIO access key.
+
+#### `aws_s3_secret_key=BB`
+
+The MinIO access key secret.
+
+#### `aws_s3_use_instance_profile=false`
+
+When using MinIO an access key is used, and so instance profiles are not used with MinIO.
+
+#### `aws_s3_use_aws_sdk_default_behavior=false`
+
+When using MinIO this parameter is always set to false.
+
+#### `enable_load_volume_from_conf=true`
+
+When this is true, a StarRocks storage volume named `builtin_storage_volume` is created using MinIO object storage, and it is set to be the default storage volume for the tables that you create.
+
+### Configuring FQDN mode
+
+The command to start the FE is also changed. The FE service command in the Docker Compose file has the option `--host_type FQDN` added. By setting `host_type` to `FQDN` the Stream Load job is forwarded to the fully qualified domain name of the CN pod, rather than the IP address. This is done because the IP address is in a range assigned to the Docker environment, and is not typically available from the host machine.
+
+These three changes allow the CN to be forwarded to from the host network:
+
+- setting `--host_type` to `FQDN`
+- exposing the CN port 8040 to the host network
+- adding an entry to the hosts file for `starrocks-cn` pointing to `127.0.0.1`
+
+---
+
+## Summary
+
+In this tutorial you:
+
+- Deployed StarRocks and Minio in Docker
+- Created a MinIO access key
+- Configured a StarRocks Storage Volume that uses MinIO
+- Loaded crash data provided by New York City and weather data provided by NOAA
+- Analyzed the data using SQL JOINs to find out that driving in low visibility or icy streets is a bad idea
+
+There is more to learn; we intentionally glossed over the data transform done during the Stream Load. The details on that are in the notes on the curl commands below.
+
+## Notes on the curl commands
+
+<Curl />
+
+## More information
+
+[StarRocks table design](../table_design/StarRocks_table_design.md)
+
+[Materialized views](../cover_pages/mv_use_cases.mdx)
+
+[Stream Load](../sql-reference/sql-statements/data-manipulation/STREAM_LOAD.md)
+
+The [Motor Vehicle Collisions - Crashes](https://data.cityofnewyork.us/Public-Safety/Motor-Vehicle-Collisions-Crashes/h9gi-nx95) dataset is provided by New York City subject to these [terms of use](https://www.nyc.gov/home/terms-of-use.page) and [privacy policy](https://www.nyc.gov/home/privacy-policy.page).
+
+The [Local Climatological Data](https://www.ncdc.noaa.gov/cdo-web/datatools/lcd)(LCD) is provided by NOAA with this [disclaimer](https://www.noaa.gov/disclaimer) and this [privacy policy](https://www.noaa.gov/protecting-your-privacy).

--- a/docs/en/quick_start/shared-nothing.md
+++ b/docs/en/quick_start/shared-nothing.md
@@ -1,0 +1,237 @@
+---
+displayed_sidebar: "English"
+sidebar_position: 1
+description: "StarRocks in Docker: Query real data with JOINs"
+---
+import DDL from '../_assets/quick-start/_DDL.mdx'
+import Clients from '../_assets/quick-start/_clientsAllin1.mdx'
+import SQL from '../_assets/quick-start/_SQL.mdx'
+import Curl from '../_assets/quick-start/_curl.mdx'
+
+# Deploy StarRocks with Docker
+
+This tutorial covers:
+
+- Running StarRocks in a single Docker container
+- Loading two public datasets including basic transformation of the data
+- Analyzing the data with SELECT and JOIN
+- Basic data transformation (the **T** in ETL)
+
+The data used is provided by NYC OpenData and the National Centers for Environmental Information.
+
+Both of these datasets are very large, and because this tutorial is intended to help you get exposed to working with StarRocks we are not going to load data for the past 120 years. You can run the Docker image and load this data on a machine with 4 GB RAM assigned to Docker. For larger fault-tolerant and scalable deployments we have other documentation and will provide that later.
+
+There is a lot of information in this document, and it is presented with the step by step content at the beginning, and the technical details at the end. This is done to serve these purposes in this order:
+
+1. Allow the reader to load data in StarRocks and analyze that data.
+2. Explain the basics of data transformation during loading.
+
+---
+
+## Prerequisites
+
+### Docker
+
+- [Docker](https://docs.docker.com/engine/install/)
+- 4 GB RAM assigned to Docker
+- 10 GB free disk space assigned to Docker
+
+### SQL client
+
+You can use the SQL client provided in the Docker environment, or use one on your system. Many MySQL compatible clients will work, and this guide covers the configuration of DBeaver and MySQL WorkBench.
+
+### curl
+
+`curl` is used to issue the data load job to StarRocks, and to download the datasets. Check to see if you have it installed by running `curl` or `curl.exe` at your OS prompt. If curl is not installed, [get curl here](https://curl.se/dlwiz/?type=bin).
+
+---
+
+## Terminology
+
+### FE
+
+Frontend nodes are responsible for metadata management, client connection management, query planning, and query scheduling. Each FE stores and maintains a complete copy of metadata in its memory, which guarantees indiscriminate services among the FEs.
+
+### BE
+
+Backend nodes are responsible for both data storage and executing query plans.
+
+---
+
+## Launch StarRocks
+
+```bash
+docker run -p 9030:9030 -p 8030:8030 -p 8040:8040 -itd \
+--name quickstart starrocks/allin1-ubuntu
+```
+
+---
+
+## SQL clients
+
+<Clients />
+
+---
+
+## Download the data
+
+Download these two datasets to your machine. You can download them to the host machine where you are running Docker, they do not need to be downloaded inside the container.
+
+### New York City crash data
+
+```bash
+curl -O https://raw.githubusercontent.com/StarRocks/demo/master/documentation-samples/quickstart/datasets/NYPD_Crash_Data.csv
+```
+
+### Weather data
+
+```bash
+curl -O https://raw.githubusercontent.com/StarRocks/demo/master/documentation-samples/quickstart/datasets/72505394728.csv
+```
+
+---
+
+### Connect to StarRocks with a SQL client
+
+:::tip
+
+If you are using a client other than the mysql CLI, open that now.
+:::
+
+This command will run the `mysql` command in the Docker container:
+
+```sql
+docker exec -it quickstart \
+mysql -P 9030 -h 127.0.0.1 -u root --prompt="StarRocks > "
+```
+
+---
+
+## Create some tables
+
+<DDL />
+
+---
+
+## Load two datasets
+
+There are many ways to load data into StarRocks. For this tutorial the simplest way is to use curl and StarRocks Stream Load.
+
+:::tip
+Open a new shell as these curl commands are run at the operating system prompt, not in the `mysql` client. The commands refer to the datasets that you downloaded, so run them from the directory where you downloaded the files.
+
+You will be prompted for a password. You probably have not assigned a password to the MySQL `root` user, so just hit enter.
+:::
+
+The `curl` commands look complex, but they are explained in detail at the end of the tutorial. For now, we recommend running the commands and running some SQL to analyze the data, and then reading about the data loading details at the end.
+
+### New York City collision data - Crashes
+
+```bash
+curl --location-trusted -u root             \
+    -T ./NYPD_Crash_Data.csv                \
+    -H "label:crashdata-0"                  \
+    -H "column_separator:,"                 \
+    -H "skip_header:1"                      \
+    -H "enclose:\""                         \
+    -H "max_filter_ratio:1"                 \
+    -H "columns:tmp_CRASH_DATE, tmp_CRASH_TIME, CRASH_DATE=str_to_date(concat_ws(' ', tmp_CRASH_DATE, tmp_CRASH_TIME), '%m/%d/%Y %H:%i'),BOROUGH,ZIP_CODE,LATITUDE,LONGITUDE,LOCATION,ON_STREET_NAME,CROSS_STREET_NAME,OFF_STREET_NAME,NUMBER_OF_PERSONS_INJURED,NUMBER_OF_PERSONS_KILLED,NUMBER_OF_PEDESTRIANS_INJURED,NUMBER_OF_PEDESTRIANS_KILLED,NUMBER_OF_CYCLIST_INJURED,NUMBER_OF_CYCLIST_KILLED,NUMBER_OF_MOTORIST_INJURED,NUMBER_OF_MOTORIST_KILLED,CONTRIBUTING_FACTOR_VEHICLE_1,CONTRIBUTING_FACTOR_VEHICLE_2,CONTRIBUTING_FACTOR_VEHICLE_3,CONTRIBUTING_FACTOR_VEHICLE_4,CONTRIBUTING_FACTOR_VEHICLE_5,COLLISION_ID,VEHICLE_TYPE_CODE_1,VEHICLE_TYPE_CODE_2,VEHICLE_TYPE_CODE_3,VEHICLE_TYPE_CODE_4,VEHICLE_TYPE_CODE_5" \
+    -XPUT http://localhost:8030/api/quickstart/crashdata/_stream_load
+```
+
+Here is the output of the preceding command. The first highlighted section shows what you should expect to see (OK and all but one row inserted). One row was filtered out because it does not contain the correct number of columns.
+
+```bash
+Enter host password for user 'root':
+{
+    "TxnId": 2,
+    "Label": "crashdata-0",
+    "Status": "Success",
+    # highlight-start
+    "Message": "OK",
+    "NumberTotalRows": 423726,
+    "NumberLoadedRows": 423725,
+    # highlight-end
+    "NumberFilteredRows": 1,
+    "NumberUnselectedRows": 0,
+    "LoadBytes": 96227746,
+    "LoadTimeMs": 1013,
+    "BeginTxnTimeMs": 21,
+    "StreamLoadPlanTimeMs": 63,
+    "ReadDataTimeMs": 563,
+    "WriteDataTimeMs": 870,
+    "CommitAndPublishTimeMs": 57,
+    # highlight-start
+    "ErrorURL": "http://127.0.0.1:8040/api/_load_error_log?file=error_log_da41dd88276a7bfc_739087c94262ae9f"
+    # highlight-end
+}%
+```
+
+If there was an error the output provides a URL to see the error messages. Open this in a browser to find out what happened. Expand the detail to see the error message:
+
+<details>
+
+<summary>Reading error messages in the browser</summary>
+
+```bash
+Error: Value count does not match column count. Expect 29, but got 32.
+
+Column delimiter: 44,Row delimiter: 10.. Row: 09/06/2015,14:15,,,40.6722269,-74.0110059,"(40.6722269, -74.0110059)",,,"R/O 1 BEARD ST. ( IKEA'S 
+09/14/2015,5:30,BRONX,10473,40.814551,-73.8490955,"(40.814551, -73.8490955)",TORRY AVENUE                    ,NORTON AVENUE                   ,,0,0,0,0,0,0,0,0,Driver Inattention/Distraction,Unspecified,,,,3297457,PASSENGER VEHICLE,PASSENGER VEHICLE,,,
+```
+
+</details>
+
+### Weather data
+
+Load the weather dataset in the same manner as you loaded the crash data.
+
+```bash
+curl --location-trusted -u root             \
+    -T ./72505394728.csv                    \
+    -H "label:weather-0"                    \
+    -H "column_separator:,"                 \
+    -H "skip_header:1"                      \
+    -H "enclose:\""                         \
+    -H "max_filter_ratio:1"                 \
+    -H "columns: STATION, DATE, LATITUDE, LONGITUDE, ELEVATION, NAME, REPORT_TYPE, SOURCE, HourlyAltimeterSetting, HourlyDewPointTemperature, HourlyDryBulbTemperature, HourlyPrecipitation, HourlyPresentWeatherType, HourlyPressureChange, HourlyPressureTendency, HourlyRelativeHumidity, HourlySkyConditions, HourlySeaLevelPressure, HourlyStationPressure, HourlyVisibility, HourlyWetBulbTemperature, HourlyWindDirection, HourlyWindGustSpeed, HourlyWindSpeed, Sunrise, Sunset, DailyAverageDewPointTemperature, DailyAverageDryBulbTemperature, DailyAverageRelativeHumidity, DailyAverageSeaLevelPressure, DailyAverageStationPressure, DailyAverageWetBulbTemperature, DailyAverageWindSpeed, DailyCoolingDegreeDays, DailyDepartureFromNormalAverageTemperature, DailyHeatingDegreeDays, DailyMaximumDryBulbTemperature, DailyMinimumDryBulbTemperature, DailyPeakWindDirection, DailyPeakWindSpeed, DailyPrecipitation, DailySnowDepth, DailySnowfall, DailySustainedWindDirection, DailySustainedWindSpeed, DailyWeather, MonthlyAverageRH, MonthlyDaysWithGT001Precip, MonthlyDaysWithGT010Precip, MonthlyDaysWithGT32Temp, MonthlyDaysWithGT90Temp, MonthlyDaysWithLT0Temp, MonthlyDaysWithLT32Temp, MonthlyDepartureFromNormalAverageTemperature, MonthlyDepartureFromNormalCoolingDegreeDays, MonthlyDepartureFromNormalHeatingDegreeDays, MonthlyDepartureFromNormalMaximumTemperature, MonthlyDepartureFromNormalMinimumTemperature, MonthlyDepartureFromNormalPrecipitation, MonthlyDewpointTemperature, MonthlyGreatestPrecip, MonthlyGreatestPrecipDate, MonthlyGreatestSnowDepth, MonthlyGreatestSnowDepthDate, MonthlyGreatestSnowfall, MonthlyGreatestSnowfallDate, MonthlyMaxSeaLevelPressureValue, MonthlyMaxSeaLevelPressureValueDate, MonthlyMaxSeaLevelPressureValueTime, MonthlyMaximumTemperature, MonthlyMeanTemperature, MonthlyMinSeaLevelPressureValue, MonthlyMinSeaLevelPressureValueDate, MonthlyMinSeaLevelPressureValueTime, MonthlyMinimumTemperature, MonthlySeaLevelPressure, MonthlyStationPressure, MonthlyTotalLiquidPrecipitation, MonthlyTotalSnowfall, MonthlyWetBulb, AWND, CDSD, CLDD, DSNW, HDSD, HTDD, NormalsCoolingDegreeDay, NormalsHeatingDegreeDay, ShortDurationEndDate005, ShortDurationEndDate010, ShortDurationEndDate015, ShortDurationEndDate020, ShortDurationEndDate030, ShortDurationEndDate045, ShortDurationEndDate060, ShortDurationEndDate080, ShortDurationEndDate100, ShortDurationEndDate120, ShortDurationEndDate150, ShortDurationEndDate180, ShortDurationPrecipitationValue005, ShortDurationPrecipitationValue010, ShortDurationPrecipitationValue015, ShortDurationPrecipitationValue020, ShortDurationPrecipitationValue030, ShortDurationPrecipitationValue045, ShortDurationPrecipitationValue060, ShortDurationPrecipitationValue080, ShortDurationPrecipitationValue100, ShortDurationPrecipitationValue120, ShortDurationPrecipitationValue150, ShortDurationPrecipitationValue180, REM, BackupDirection, BackupDistance, BackupDistanceUnit, BackupElements, BackupElevation, BackupEquipment, BackupLatitude, BackupLongitude, BackupName, WindEquipmentChangeDate" \
+    -XPUT http://localhost:8030/api/quickstart/weatherdata/_stream_load
+```
+
+---
+
+## Answer some questions
+
+<SQL />
+
+---
+
+## Summary
+
+In this tutorial you:
+
+- Deployed StarRocks in Docker
+- Loaded crash data provided by New York City and weather data provided by NOAA
+- Analyzed the data using SQL JOINs to find out that driving in low visibility or icy streets is a bad idea
+
+There is more to learn; we intentionally glossed over the data transformation done during the Stream Load. The details on that are in the notes on the curl commands below.
+
+---
+
+## Notes on the curl commands
+
+<Curl />
+
+---
+
+## More information
+
+[StarRocks table design](../table_design/StarRocks_table_design.md)
+
+[Materialized views](../cover_pages/mv_use_cases.mdx)
+
+[Stream Load](../sql-reference/sql-statements/data-manipulation/STREAM_LOAD.md)
+
+The [Motor Vehicle Collisions - Crashes](https://data.cityofnewyork.us/Public-Safety/Motor-Vehicle-Collisions-Crashes/h9gi-nx95) dataset is provided by New York City subject to these [terms of use](https://www.nyc.gov/home/terms-of-use.page) and [privacy policy](https://www.nyc.gov/home/privacy-policy.page).
+
+The [Local Climatological Data](https://www.ncdc.noaa.gov/cdo-web/datatools/lcd)(LCD) is provided by NOAA with this [disclaimer](https://www.noaa.gov/disclaimer) and this [privacy policy](https://www.noaa.gov/protecting-your-privacy).


### PR DESCRIPTION
To translate changed Markdown files we first have to generate a list of changed Markdown files. This PR:

- Copies in docs dir structure from StarRocks docs
- Copies in sample detect changed files from tj-actions/changed-files

The output of the workflow is:

```bash
Run for file in ${ALL_CHANGED_FILES}; do
.github/workflows/translate.yml was changed
docs/en/quick_start/helm.md was changed
docs/en/quick_start/hudi.md was changed
docs/en/quick_start/iceberg.md was changed
docs/en/quick_start/quick_start.mdx was changed
docs/en/quick_start/routine-load.md was changed
docs/en/quick_start/shared-data.md was changed
docs/en/quick_start/shared-nothing.md was changed
```

The input that the tcapelle/gpt_translate action wants is a txt file containing:

```bash
docs/another_file.md
docs/intro.md
```

The changes needed are:
- only output changed `.md` and `.mdx` files
- limit to contents of `docs/en/**` 
- remove " was changed"

